### PR TITLE
deploy: sync skills from vault (2026-04-18)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-skills",
   "description": "Personal Claude Code skill collection by Beomsu Koh",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": {
     "name": "Beomsu Koh"
   },

--- a/skills/obsidian-sync/SKILL.md
+++ b/skills/obsidian-sync/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: obsidian-sync
+description: Safely bootstrap, reconfigure, operate, or investigate `obsidian-headless` (ob CLI) sync between the Ataraxia SSOT (M3, GUI) and headless replicas (M1-pro, pm2 daemon). Use when the user wants to set up `ob sync` on a new machine, add/remove a vault sync config, flip modes (pull-only, bidirectional, mirror-remote), drive remote sync ops from SSOT via tailscale, inspect or restart the pm2 `ob-sync-ataraxia` daemon on M1, investigate files that may have been deleted by sync, recover from a silent-deletion incident, verify the multi-layer deletion defense stack, or asks about "ob sync", "obsidian sync", "obsidian-headless", "vault sync", "sync incident", "headless sync", "pm2 ob sync", or "m1 sync". The headless CLI can silently delete thousands of files on race conditions or remote corruption, so the safe path requires pull-only staging plus parity verification BEFORE bidirectional. All replica ops are authored on M3 and executed over `ssh m1-pro`; never author sync changes on the replica.
+---
+
+# Obsidian Sync
+
+## Overview
+
+The `obsidian-headless` CLI (`ob`) is a no-GUI sync client for Obsidian Sync. It is powerful but dangerous: a bad config, a corrupted remote, or a race condition with the Obsidian GUI can cascade into silent bulk deletion of notes across machines. This skill defines the safe bootstrap workflow, the daily operation surface, and the multi-layer defenses that must be in place before any `ob sync` command runs.
+
+The operating principle: **every sync change is staged, verified with evidence, and reversible**. Never enable `bidirectional` or `--continuous` without first confirming parity in `pull-only` mode and having a git safety tag to roll back to.
+
+## Topology (SSOT-first)
+
+- **M3 (SSOT)** — primary machine, runs the Obsidian GUI, holds the authoritative vault at `/Users/beomsu/Documents/01. Obsidian/Ataraxia`. Claude Code and skill workflows execute here. Does NOT run `ob sync`.
+- **M1-pro (headless replica)** — no GUI, runs `ob sync --continuous` under pm2 as `ob-sync-ataraxia`. The vault path mirrors M3 exactly.
+- **Transport** — tailscale. All replica-side operations (pm2 inspect/restart, `ob` status, log tail, plist management) are driven from M3 by `ssh m1-pro …`. See `references/remote-m1-ops.md`.
+
+If you are tempted to `ssh` into M1 and run `ob sync-setup` or edit pm2 config interactively, stop — invoke the workflow from M3 and let the remote command be the terminal leaf of an SSOT-authored plan.
+
+## When to Use
+
+- Adding, removing, or retargeting an `ob sync` vault config on any machine
+- Switching sync mode (`bidirectional` <-> `pull-only` <-> `mirror-remote`)
+- Setting up sync on a new headless replica
+- Inspecting, restarting, or changing the pm2 `ob-sync-ataraxia` daemon on M1
+- Investigating a vault where many files appear to be missing or recently deleted
+- Verifying the multi-layer deletion defense stack after changes
+- Post-incident recovery and drill runs
+
+Do NOT use for:
+- Obsidian GUI "Settings > Sync" configuration on M3 (different code path; handled in the GUI)
+- `ob publish` publish-site operations (separate command family)
+- Generic git conflict or rsync issues unrelated to Obsidian Sync
+- Tailscale itself, beyond the SSOT→replica operational pattern (see the `tailscale` skill)
+
+## Core Process
+
+The safe bootstrap workflow runs in four phases: **Preflight -> Stage -> Verify -> Promote**. Each phase must finish with explicit evidence before the next begins. For daily operations against an already-bootstrapped replica, skip to the "Daily Operations" section below.
+
+### Phase 1: Preflight
+
+1. Confirm the role of each machine: M3 is SSOT (GUI), M1 is the replica (`ob sync` under pm2). Only the replica runs `ob sync`.
+2. Take a git safety snapshot on every machine that owns a live vault:
+   ```bash
+   cd "<vault-path>"
+   git add --update && git commit -m "pre-sync snapshot $(date -u +%Y%m%dT%H%M%SZ)"
+   git tag "safety/pre-sync-$(date -u +%Y%m%d-%H%M%S)"
+   ```
+3. Capture the md file count (this is the invariant you will compare after):
+   ```bash
+   find "<vault-path>" -name "*.md" -not -path "*/.git/*" | wc -l
+   ```
+4. Confirm the multi-layer defense stack is installed and correct. See `references/defense-stack.md` for the full checklist; the short form:
+   - PreToolUse hook exits 2 on piped deletion/push patterns
+   - `.claude/settings.json` permission `deny` list covers `rm *`, `git rm *`, `git clean *`, `git push origin *`, `git push * --force*`
+   - `.git/hooks/pre-commit` blocks bulk md deletions above a threshold
+   - `git config --get core.hooksPath` is **empty or points to a real directory** (see Red Flags)
+5. Confirm tailscale reachability to the replica before any remote operation:
+   ```bash
+   tailscale status | grep m1-pro
+   tailscale ping --tsmp m1-pro | head -3
+   ```
+   If unreachable, fix connectivity first. See the `tailscale` skill for triage.
+6. Close the Obsidian GUI on the replica and stop any launchd agent that re-spawns it (e.g., `ai.openclaw.gateway`, `ai.openclaw.gateway-watchdog`). See `references/launchd-respawn.md`.
+
+### Phase 2: Stage (pull-only)
+
+All commands in this phase target the replica. From M3, prefix each with `ssh m1-pro` (see `references/remote-m1-ops.md`) unless you are on the replica via an interactive terminal for the password-prompt step.
+
+1. List the remote vaults and confirm the target vault still exists on the server — remote vaults can be deleted:
+   ```bash
+   ob sync-list-remote
+   ```
+2. List and remove any stale local configs that point to wrong paths or obsolete devices:
+   ```bash
+   ob sync-list-local
+   ob sync-unlink --path "<stale-or-old-path>"
+   ```
+3. Pair the target local path to the remote vault. This prompts for the end-to-end encryption password interactively, so it must run in a real TTY (do not pipe `< /dev/null`, and do not invoke through a non-interactive ssh):
+   ```bash
+   ob sync-setup \
+     --vault "<vault-id-or-name>" \
+     --path "<local-vault-path>" \
+     --device-name "<this-machine-name>"
+   ```
+4. Switch the new config to `pull-only` BEFORE the first sync. This is the single most important guard against an accidental destructive push:
+   ```bash
+   ob sync-config --path "<local-vault-path>" --mode pull-only
+   ```
+5. Run **one** non-continuous sync and capture output:
+   ```bash
+   ob sync --path "<local-vault-path>" 2>&1 | tee /tmp/ob-first-pull.log
+   ```
+
+### Phase 3: Verify
+
+1. Re-measure the md file count. If the delta is larger than expected (for example, thousands of files changed when only days of drift were expected), STOP and investigate before proceeding.
+2. Scan the sync log for error signatures:
+   - `The connected remote vault no longer exists` -> the remote vault is gone; restart Phase 2 with a live vault
+   - `Failed to authenticate: Vault not found` -> same as above
+   - `Failed to validate password` -> wrong E2E password, retry `sync-setup`
+3. Cross-check with `git status` and `git log`: the files that changed should be a plausible diff, not a wholesale wipe.
+4. If any check fails, roll back with `git reset --hard safety/pre-sync-<timestamp>` and do not proceed.
+
+### Phase 4: Promote
+
+1. Flip mode to `bidirectional` once parity is confirmed and the diff makes sense:
+   ```bash
+   ob sync-config --path "<local-vault-path>" --mode bidirectional
+   ```
+2. Run one more one-shot sync and re-verify.
+3. Only now enable continuous daemon mode. On M1-pro this is done under pm2 with a dedicated ecosystem file at `~/.config/pm2/ob-sync-ataraxia.config.cjs`; see `references/pm2-daemon.md` for the full config and healthcheck. Minimum-viable form:
+   ```bash
+   ob sync --path "<local-vault-path>" --continuous
+   ```
+4. Decide the fate of any launchd agents that were suspended in Phase 1. Two patterns apply (see `references/launchd-respawn.md`):
+   - **One-shot bootstrap**: restore with `launchctl bootstrap gui/$(id -u) <plist>`.
+   - **Continuous daemon (the M1-pro case)**: if the agent spawns the Obsidian GUI, delete the plist instead — a persistent daemon cannot coexist with recurring GUI spawns.
+
+## Daily Operations (M3 → M1 over tailscale)
+
+For a replica that is already bootstrapped and running under pm2, most ops are read-only inspections. All of the below run from M3. See `references/remote-m1-ops.md` for the full command catalog.
+
+- **Health check** (should be a reflex before any sync change):
+  ```bash
+  ssh m1-pro 'pm2 list | grep ob-sync-ataraxia && tail -n 5 ~/.pm2/logs/ob-sync-ataraxia-out.log'
+  ```
+  Expect: `status=online`, low restart count, recurring `Fully synced` lines.
+- **Restart daemon** (e.g., after a config edit on the replica):
+  ```bash
+  ssh m1-pro 'pm2 restart ob-sync-ataraxia --update-env && pm2 save'
+  ```
+- **Stop daemon immediately** (panic stop if a bad release is suspected):
+  ```bash
+  ssh m1-pro 'pm2 stop ob-sync-ataraxia'
+  ```
+  Stopping pm2 does not undo whatever was already synced — the git safety tag on the affected vault is what gets you back.
+- **Change sync mode on the replica** (e.g., bidirectional ↔ pull-only):
+  ```bash
+  ssh m1-pro 'ob sync-config --path "/Users/beomsu/Documents/01. Obsidian/Ataraxia" --mode pull-only'
+  ssh m1-pro 'pm2 restart ob-sync-ataraxia'
+  ```
+  A mode flip on a continuous daemon still requires a restart to re-read config.
+
+Any operation more destructive than "inspect" (mode change, unlink, setup) must be preceded by a git safety tag on both M3 and M1 and followed by the Verify phase checks.
+
+## Sync Modes
+
+Pick the mode based on the risk budget. Modes are changed via `ob sync-config --mode`.
+
+| Mode | Behavior | Safe to enable first time? |
+|---|---|---|
+| `bidirectional` (default) | Uploads local changes AND downloads remote changes. | No — never enable before a parity check. |
+| `pull-only` | Downloads remote changes; ignores local-only files (keeps them). Remote deletions still apply locally. | Yes — this is the staging mode. |
+| `mirror-remote` | Downloads remote changes AND reverts any local-only changes. Destructive to local. | No — only for "I want this machine to exactly mirror the server". |
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Pull-only is completely safe, nothing can get deleted." | Remote deletions still propagate to local in pull-only mode. A corrupted remote can wipe files locally. |
+| "The pre-commit guard will catch bulk deletions." | Only if `core.hooksPath` resolves to a real directory. Silent hook misconfig is a known incident vector; always `git config --get core.hooksPath` as part of preflight. |
+| "Closing Obsidian GUI once is enough." | Launchd agents (e.g., `ai.openclaw.gateway`) can re-spawn the GUI within seconds. Both the agent and its watchdog must be suspended for the duration of the sync — or permanently removed on the continuous-daemon replica. |
+| "v0.0.8 is the current npm release, so it must be stable." | v0.0.8 is the incident version that silently deleted thousands of files. Pin or stay on the last known-good version until a verified fix ships. |
+| "The remote vault is the source of truth — just pull it." | The remote vault can be deleted or corrupted by the server side. See `references/incident-timeline.md` for the case where the remote vault vanished entirely. |
+| "I'll skip the git safety tag, the vault is already in git." | A loose `HEAD` is not a named rollback point. Without the `safety/pre-sync-*` tag, rollback requires commit archaeology under time pressure. |
+| "I'll just ssh into M1 and fix it there." | SSOT drift. Changes authored on the replica are invisible to M3's skill/plan history. Drive every change from M3; the ssh hop is the leaf, not the workspace. |
+
+## Red Flags
+
+Stop and investigate if any of these are observed:
+
+- `ob sync-status` shows a vault path with a typo (e.g., missing `01. ` prefix) — high risk of misconfig, same class as the `core.hooksPath` bug
+- `git config --get core.hooksPath` returns a path that does not exist
+- `ob sync-list-remote` does not contain the vault you expect to sync to
+- The first `ob sync` log contains `The connected remote vault no longer exists`
+- The md file count after a pull changes by more than a few hundred when you only expected days of drift
+- An unexpected Obsidian process keeps re-appearing in `ps` while you try to shut it down on the replica
+- `encryptionVersion: 0` in the config.json on a fresh setup — current Obsidian Sync uses v3+; a v0 config is a stale leftover
+- Sync-setup stalls with no password prompt — likely running in a non-TTY context (e.g., non-interactive ssh); re-run from a real terminal with `!` in the chat prompt
+- `tailscale ping m1-pro` fails, OR `ssh m1-pro` works but `pm2 list` is empty — the replica is reachable but the daemon is gone; do not re-setup blindly, first inspect `~/.pm2/dump.pm2` and `~/.pm2/logs/`
+
+## Verification
+
+After any sync change, confirm:
+
+- [ ] A `safety/pre-sync-*` git tag exists on every changed machine
+- [ ] md file count delta is explained and plausible
+- [ ] `ob sync-list-local` shows only the intended vaults and correct paths
+- [ ] `ob sync-status` reports the expected mode and device name
+- [ ] One non-continuous `ob sync` run completed cleanly before `--continuous` was enabled
+- [ ] Defense stack verification: `echo '{"tool_input":{"command":"rm -rf x"}}' | .claude/hooks/block-git-dangerous.sh; echo $?` prints `2`
+- [ ] Pre-commit guard drill: stage 101 nested md deletions on a throwaway branch, attempt commit, observe the guard block; separately commit a 2-file delete and observe it succeed
+- [ ] On the replica: `pm2 list | grep ob-sync-ataraxia` shows `online`, restarts low, and logs carry a recent `Fully synced` heartbeat
+- [ ] Any launchd agents stopped in Phase 1 are restored — or, on the continuous-daemon replica, confirmed permanently removed per `references/launchd-respawn.md`
+
+For the full post-incident drill protocol, see `references/drill-protocol.md`.
+
+## Related Files
+
+- `references/remote-m1-ops.md` — SSOT→replica command catalog (tailscale-mediated pm2 / ob inspect / log tail / restart)
+- `references/incident-timeline.md` — 2026-04-17 silent-deletion incident and the bugs it surfaced
+- `references/defense-stack.md` — Layer 0/1/2 deletion defenses, config locations, and exit-code semantics
+- `references/cli-commands.md` — `ob` command reference with flag-level detail
+- `references/drill-protocol.md` — Step-by-step verification drill for the multi-layer defenses
+- `references/launchd-respawn.md` — How to suspend, restore, or permanently remove Obsidian-respawning launchd agents
+- `references/pm2-daemon.md` — pm2 ecosystem, healthcheck, and rollback for `ob sync --continuous` on the headless replica

--- a/skills/obsidian-sync/references/cli-commands.md
+++ b/skills/obsidian-sync/references/cli-commands.md
@@ -1,0 +1,108 @@
+# `ob` CLI Command Reference
+
+The headless client is installed as the global command `ob` (npm package `obsidian-headless`). Binary typically lives at `/opt/homebrew/bin/ob`. Version `0.0.8` is the last known-good at the time of writing **and** the version involved in the 2026-04-17 incident — treat it as fragile.
+
+## Install and inspect
+
+```bash
+npm install -g obsidian-headless       # install or upgrade
+npm view obsidian-headless version     # check latest on npm
+ob --version                            # check locally installed version
+```
+
+Configuration lives under `~/.obsidian-headless/` (note: **not** `~/.config/obsidian-headless/`):
+
+- `~/.obsidian-headless/auth_token` — login token (set by `ob login`)
+- `~/.obsidian-headless/sync/<vaultId>/config.json` — per-vault config
+- `~/.obsidian-headless/sync/<vaultId>/state.db` — sync state database
+- `~/.obsidian-headless/sync/<vaultId>/sync.log` — rolling sync log
+
+## Command surface
+
+```
+ob login                 login to Obsidian account or show login status
+ob logout                log out
+ob sync-list-remote      list vaults available on the server
+ob sync-list-local       list locally configured vaults
+ob sync-create-remote    create a new remote vault
+ob sync-setup            connect a local path to a remote vault
+ob sync-config           change sync configuration for a local vault
+ob sync-status           show current sync configuration for a local vault
+ob sync-unlink           disconnect a local vault and remove stored credentials
+ob sync                  run sync (once, or --continuous)
+ob publish-*             publish-site family (different code path, out of scope)
+```
+
+## `sync-setup`
+
+```
+--vault <id-or-name>             remote vault identifier
+--path <local-path>              local vault path (default: cwd)
+--password <passphrase>          E2E encryption password (prompted if omitted)
+--device-name <name>             label for this machine in sync history
+--config-dir <name>              config directory name (default: .obsidian)
+```
+
+**Interactive password caveat:** `sync-setup` must run in a real TTY for the password prompt. Piping `< /dev/null` fails with `Failed to validate password`. In a Claude Code chat, use the `!` prefix so the command attaches to the user's terminal.
+
+## `sync-config`
+
+```
+--path <local-path>              which local vault
+--mode <mode>                    bidirectional | pull-only | mirror-remote
+--conflict-strategy <strategy>   merge | conflict
+--excluded-folders <folders>     comma-separated paths; empty string clears
+--file-types <types>             image, audio, video, pdf, unsupported; empty clears
+--configs <settings>             app, appearance, hotkey, core-plugin, core-plugin-data, community-plugin, community-plugin-data
+--device-name <name>             change the device label
+--config-dir <name>              default: .obsidian
+```
+
+**Mode semantics:**
+
+- `bidirectional` — default. Uploads local changes and downloads remote changes.
+- `pull-only` — download only. Ignores local-only additions (keeps them). Remote deletions still propagate.
+- `mirror-remote` — download only. Reverts local-only additions. Destructive to local work.
+
+**File-type note:** `--file-types` controls *attachments*. Markdown is always synced regardless.
+
+## `sync`
+
+```
+--path <local-path>              target vault
+--continuous                     run as a long-lived daemon
+```
+
+Never enable `--continuous` in a first-sync run. Always start with a one-shot sync and confirm the diff is expected.
+
+## Config.json shape
+
+A healthy `config.json` looks like this (real keys redacted):
+
+```json
+{
+  "vaultId": "<32-hex>",
+  "vaultName": "Vault Name",
+  "vaultPath": "/absolute/path/to/vault",
+  "host": "sync-XX.obsidian.md",
+  "encryptionVersion": 3,
+  "encryptionKey": "<base64>",
+  "encryptionSalt": "<hex>",
+  "conflictStrategy": "merge",
+  "deviceName": "this-machine",
+  "syncMode": "bidirectional",
+  "fileTypes": [],
+  "ignoreFolders": ["path/to/ignore"]
+}
+```
+
+**`encryptionVersion: 0`** in a fresh setup is a red flag: current Obsidian Sync uses v3+. A v0 config is almost certainly stale and should be `sync-unlink`-ed and re-created via `sync-setup`.
+
+## Common errors and meaning
+
+| Error text | Meaning | Action |
+|---|---|---|
+| `The connected remote vault no longer exists` | Server-side vault gone | Re-run `sync-list-remote`, pick a live vault, `sync-setup` against it |
+| `Failed to authenticate: Vault not found` | Same as above, usually paired | See above |
+| `Failed to validate password` | Wrong E2E passphrase or non-TTY invocation | Re-run in a real terminal with the correct password |
+| `Sync error: ECONNRESET` | Transient network | Retry; if persistent, check `sync.log` and rotate auth (`ob logout && ob login`) |

--- a/skills/obsidian-sync/references/defense-stack.md
+++ b/skills/obsidian-sync/references/defense-stack.md
@@ -1,0 +1,119 @@
+# Multi-Layer Deletion Defense Stack
+
+Three independent layers must be in place before any `ob sync` command runs. They are ordered by how early they catch a destructive action: the earlier the layer, the less state has been mutated when it fires.
+
+## Layer 0 — PreToolUse hook (authoritative block)
+
+**Location:** `.claude/hooks/block-git-dangerous.sh` in the vault repo.
+
+**What it does:** intercepts every Claude Code `Bash` tool call. Parses the JSON tool input, greps the command string against a deny pattern list, and exits with code `2` on a match. Exit 2 is bypass-proof — it blocks even under `bypassPermissions` mode.
+
+**Deny patterns (minimum set):**
+
+```
+git add -A
+git add --all
+git push origin
+git push m1pro
+git push [^ ]* --force
+git push [^ ]* -f( |$)
+git push --force
+git push -f( |$)
+rm -rf
+git clean
+git rm
+```
+
+**Verify:**
+
+```bash
+echo '{"tool_input":{"command":"rm -rf x"}}' | .claude/hooks/block-git-dangerous.sh; echo $?
+```
+
+Expected output ends with `2`. If it prints `0`, the hook is not matching — check that `python3` is on PATH and the JSON parse step succeeded.
+
+## Layer 1 — Permission deny rules
+
+**Location:** `.claude/settings.json` in the vault repo and in any parent `.claude/settings.json` that Claude Code resolves.
+
+**Critical schema note:** `disableBypassPermissionsMode` must be nested **inside** the `permissions` block, not at the root. Putting it at the root silently fails schema validation in some Claude Code versions; nesting is the correct and forward-compatible form.
+
+```json
+{
+  "permissions": {
+    "disableBypassPermissionsMode": "disable",
+    "deny": [
+      "Bash(rm *)",
+      "Bash(rm -rf *)",
+      "Bash(rmdir *)",
+      "Bash(git rm *)",
+      "Bash(git clean *)",
+      "Bash(git add -A)",
+      "Bash(git add --all)",
+      "Bash(git push origin *)",
+      "Bash(git push * --force*)",
+      "Bash(git push --force*)",
+      "Bash(find * -delete)",
+      "Bash(find * -exec rm*)",
+      "Bash(find * -exec unlink*)",
+      "Bash(shred *)",
+      "Bash(trash *)"
+    ],
+    "allow": []
+  }
+}
+```
+
+**Caveat:** deny rules are read at session start. Adding a rule mid-session is not reliable — restart Claude Code after editing `settings.json`.
+
+## Layer 2 — Pre-commit deletion guard
+
+**Location:** `.git/hooks/pre-commit` inside the vault repo. The hook must be executable and `core.hooksPath` must NOT be set to an alternate directory that does not exist.
+
+**Preflight check (always run):**
+
+```bash
+git config --get core.hooksPath
+```
+
+If it returns anything, confirm the directory exists. Prefer `git config --unset core.hooksPath` so the default `.git/hooks/` is used — this removes one entire class of silent-disable bug.
+
+**Guard logic (canonical form):**
+
+```bash
+#!/bin/bash
+THRESHOLD="${DELETE_GUARD_THRESHOLD:-100}"
+DELETED=$(git diff --cached --diff-filter=D --name-only 2>/dev/null | grep -c '\.md$')
+DELETED="${DELETED:-0}"
+if [ "$DELETED" -ge "$THRESHOLD" ]; then
+  if [ "$ALLOW_BULK_DELETE" = "1" ]; then
+    exit 0
+  fi
+  echo "[pre-commit] $DELETED md files marked for deletion (threshold: $THRESHOLD)."
+  git diff --cached --diff-filter=D --name-only 2>/dev/null | grep '\.md$' | head -10
+  echo "To proceed intentionally: ALLOW_BULK_DELETE=1 git commit ..."
+  exit 1
+fi
+exit 0
+```
+
+**Key properties:**
+
+- Suffix grep (`grep -c '\.md$'`) — catches nested md files. Do NOT replace with `-- '*.md'` pathspec; that only matches repo root.
+- Threshold is environment-overridable (`DELETE_GUARD_THRESHOLD`).
+- Bypass is explicit and single-shot (`ALLOW_BULK_DELETE=1`). No permanent opt-out.
+
+## Codex rules (separate agent surface)
+
+Codex has its own deny surface at `~/.codex/rules/default.rules` using `prefix_rule` entries. Keep at least the same ten patterns as Layer 1 (rm, rmdir, git rm, git clean, git add -A, git add --all, git push origin, git push --force, shred, trash).
+
+## Where the locations live
+
+| File | Role |
+|---|---|
+| `.claude/hooks/block-git-dangerous.sh` | Layer 0 authoritative block |
+| `.claude/settings.json` (vault) | Layer 1 deny + bypass disable |
+| `.claude/settings.json` (parent dirs) | Layer 1 — resolved in addition to vault |
+| `.git/hooks/pre-commit` | Layer 2 bulk deletion guard |
+| `~/.codex/rules/default.rules` | Codex-side prefix_rule deny list |
+| `.omc/plans/2026-04-18-ataraxia-sync-redesign-ralplan.md` | Source of truth for all of the above |

--- a/skills/obsidian-sync/references/drill-protocol.md
+++ b/skills/obsidian-sync/references/drill-protocol.md
@@ -1,0 +1,120 @@
+# Defense Stack Verification Drill
+
+Run this drill after any change to the hooks, deny rules, or pre-commit guard. It takes about five minutes and produces direct evidence that each layer actually blocks a bulk deletion.
+
+## Preconditions
+
+- The vault is in a clean state (`git status` is clean, or at minimum there are no staged deletions).
+- A safety tag exists (`git tag | grep safety/`).
+- You know how to force-exit in case the drill triggers an unexpected action (`Ctrl+C`, kill tmux, etc.).
+
+## Drill 1: Layer 0 (PreToolUse hook) direct-pipe
+
+This tests the hook itself, without involving Claude Code. It proves the exit-2 behaviour works for piped deletion-class commands.
+
+```bash
+HOOK=".claude/hooks/block-git-dangerous.sh"
+for CMD in \
+  'rm -rf test' \
+  'git rm -r foo/' \
+  'git add -A' \
+  'git push origin main'; do
+  OUT=$(printf '{"tool_input":{"command":"%s"}}' "$CMD" | "$HOOK" 2>&1)
+  RC=$?
+  echo "cmd=[$CMD] rc=$RC out=$OUT"
+done
+```
+
+Expected: every iteration prints `rc=2` and an `out=BLOCKED by block-git-dangerous.sh: matched pattern '...'` line.
+
+## Drill 2: Layer 2 (pre-commit guard) nested bulk deletion
+
+This verifies the pre-commit guard blocks ≥ threshold md deletions at nested paths. Run on a throwaway branch so nothing actually changes on your working branch.
+
+```bash
+BRANCH="drill/pre-commit-$(date +%s)"
+THRESHOLD=100
+TARGET_DIR=".omc/drill-targets"
+
+git checkout -b "$BRANCH"
+mkdir -p "$TARGET_DIR"
+for i in $(seq 1 101); do
+  echo "drill $i" > "$TARGET_DIR/drill_$i.md"
+done
+git add "$TARGET_DIR"
+git commit -m "drill: add $((THRESHOLD + 1)) drill targets"
+
+# Stage deletions
+git rm -r "$TARGET_DIR" > /dev/null
+
+# Attempt commit — must fail
+git commit -m "drill: delete all targets (should be blocked)" 2>&1 | tee /tmp/drill-pre-commit.log
+echo "commit rc=$?"
+```
+
+Expected: the commit fails, the log contains `[pre-commit] 101 md files marked for deletion (threshold: 100).`, and `commit rc=1`.
+
+Cleanup:
+
+```bash
+git reset --hard HEAD~1
+git checkout -
+git branch -D "$BRANCH"
+```
+
+## Drill 3: Layer 2 smoke test (small deletion must pass)
+
+The guard must NOT block legitimate small edits. Stage and commit a 2-file deletion on a throwaway branch and confirm it succeeds.
+
+```bash
+BRANCH="drill/smoke-$(date +%s)"
+git checkout -b "$BRANCH"
+mkdir -p .omc/drill-smoke
+for i in 1 2; do echo smoke > .omc/drill-smoke/s_$i.md; done
+git add .omc/drill-smoke && git commit -m "drill: add 2 smoke files"
+git rm -r .omc/drill-smoke > /dev/null
+git commit -m "drill: delete 2 smoke files" 2>&1
+echo "commit rc=$?"
+
+# Cleanup
+git reset --hard HEAD~1
+git checkout -
+git branch -D "$BRANCH"
+```
+
+Expected: `commit rc=0`, no block message.
+
+## Drill 4: `core.hooksPath` sanity
+
+Before and after any change to hook config, confirm:
+
+```bash
+git config --get core.hooksPath
+ls -la .git/hooks/pre-commit
+```
+
+Expected: either no output (default hook path) or a path that actually exists; and `pre-commit` exists and is executable.
+
+## Drill 5: Codex prefix_rule sanity
+
+```bash
+grep -c '^deny ' ~/.codex/rules/default.rules
+```
+
+Expected: at least `10` matching deny entries covering rm, rmdir, git rm, git clean, git add -A, git add --all, git push origin, git push --force, shred, trash.
+
+## Reporting template
+
+Store drill evidence in `.omc/logs/drill-report-<timestamp>.md` using this shape:
+
+```
+# Defense Drill <timestamp>
+- Layer 0: 4/4 deny patterns returned rc=2 ✓
+- Layer 2 bulk: 101 md staged, commit blocked with threshold message ✓
+- Layer 2 smoke: 2 md staged, commit succeeded ✓
+- core.hooksPath: <value or "unset">
+- Codex prefix_rule deny count: <n>
+- Verdict: PASS | FAIL (and which layer failed)
+```
+
+Every drill report entry should be an atomic commit so it becomes part of the local snapshot history.

--- a/skills/obsidian-sync/references/incident-timeline.md
+++ b/skills/obsidian-sync/references/incident-timeline.md
@@ -1,0 +1,65 @@
+# 2026-04-17 Silent Deletion Incident
+
+This file captures the facts of the incident that motivated the Obsidian Sync bootstrap skill. Read it when a sync change feels low-risk — the history is the counterweight.
+
+## Summary
+
+On 2026-04-17, `ob sync --continuous` v0.0.8 silently deleted approximately **16,692 md files** from the Ataraxia vault. The deletion propagated from a race between the headless daemon and the Obsidian GUI. No layer of defense stopped it at the commit boundary because two independent bugs (see below) silently disabled the pre-commit guard.
+
+The recovery plan lives at `.omc/plans/2026-04-18-ataraxia-sync-redesign-ralplan.md` in the vault and supersedes any older sync documentation.
+
+## Bugs surfaced during the drill
+
+### Bug 1: Pre-commit pathspec
+
+Original pre-commit hook:
+
+```bash
+DELETED=$(git diff --cached --diff-filter=D --name-only -- '*.md' 2>/dev/null | wc -l)
+```
+
+The `'*.md'` pathspec only matches md files at the repo root, not in nested directories. Any deletion under `folder/*.md` counted as zero, so the threshold guard never fired for real bulk deletions (which are almost always nested).
+
+Fix (suffix grep, applied 2026-04-18 R13):
+
+```bash
+DELETED=$(git diff --cached --diff-filter=D --name-only 2>/dev/null | grep -c '\.md$')
+```
+
+### Bug 2: `core.hooksPath` misconfig
+
+```
+$ git config --get core.hooksPath
+/Users/beomsu/Documents/Obsidian/Ataraxia/.git/hooks
+```
+
+The path is missing the `01. ` directory prefix. The directory does not exist. Git silently treats the hook as absent, so `pre-commit` was never invoked on any commit, even though the file on disk was correct.
+
+Fix (applied 2026-04-18 R12):
+
+```bash
+git config --unset core.hooksPath
+```
+
+After unsetting, git resolves hooks from the default `.git/hooks/` directory inside the repo, where the guard actually lives.
+
+**Lesson:** always include `git config --get core.hooksPath` in preflight. A hook file that exists is not the same as a hook that runs.
+
+## Remote vault disappearance
+
+A separate class of failure surfaced on 2026-04-18 during the recovery drill: the old `a615980e…` "Ataraxia" remote vault returned `The connected remote vault no longer exists` on the first `ob sync`. The remote side of the sync had been deleted (likely during the incident or a cleanup that followed). Local files were untouched because `ob sync` failed at the authentication step before any file operations started.
+
+The lesson: **always run `ob sync-list-remote` before `sync-setup` or any mode change**. A remote that you last saw a month ago may not exist today.
+
+## What rolled back vs what was kept
+
+- Local vault content: restored from `safety/pre-redesign-20260418-124711` git tag.
+- Defense stack (PreToolUse hook, settings.json deny rules, pre-commit guard, Codex rules): kept and hardened.
+- `ob sync` configs on M3 (SSOT machine): removed. M3 uses the Obsidian GUI for sync; only headless replicas run `ob sync`.
+- `ob sync` config on M1 (headless replica): repaired to point at the correct local path with device name `m1-pro` and staged in `pull-only` mode pending first-pull verification.
+
+## Why this skill exists
+
+The incident was not caused by a single bug. It was caused by **three simultaneous failures** — a sync tool that didn't fail safe, a pre-commit guard that silently wasn't running, and a pathspec that never matched nested files. Any one of those fixed in isolation would not have stopped the incident.
+
+The bootstrap workflow in `SKILL.md` is designed under the assumption that silent failure is the default. Every step produces evidence, every mode change is staged, and every "safe" assumption is verified.

--- a/skills/obsidian-sync/references/launchd-respawn.md
+++ b/skills/obsidian-sync/references/launchd-respawn.md
@@ -1,0 +1,93 @@
+# Suspending Obsidian-respawning launchd agents
+
+When running `ob sync` on a machine that also has the Obsidian GUI installed, the GUI must stay closed for the duration of the sync. On this user's setup (M1-pro specifically), several launchd agents re-spawn Obsidian automatically — `pkill Obsidian` alone is not sufficient.
+
+## Identify what is respawning Obsidian
+
+```bash
+# Current parent of any live Obsidian process
+ps -eo pid,ppid,user,command | grep -i "Obsidian.app/Contents/MacOS/Obsidian" | grep -v grep
+
+# Walk up to the launch source
+ps -p <PPID> -o pid,ppid,command
+```
+
+A common pattern on this user's machines: `ai.openclaw.gateway` (PID varies) is the parent process. It is launched by macOS `launchd` and has a watchdog, so killing it directly results in a fast relaunch.
+
+## Locate the launchd plists
+
+User-level agents live in `~/Library/LaunchAgents/`. Look for anything that references Obsidian or the gateway daemon:
+
+```bash
+ls -la ~/Library/LaunchAgents/ | grep -iE "obsidian|openclaw|gateway|vault"
+launchctl list | grep -iE "obsidian|openclaw"
+```
+
+Typical set on this user's M1:
+
+- `ai.openclaw.gateway.plist` — spawns Obsidian for daily-note and vault automation
+- `ai.openclaw.gateway-watchdog.plist` — re-spawns the gateway if it dies
+- `ai.openclaw.vault-watcher.plist` — fswatch on vault; does not spawn Obsidian directly
+- `local.backup-openclaw.plist` — backup job; does not spawn Obsidian directly
+
+The first two must be suspended during `ob sync`. The last two are safe to leave running.
+
+## Suspend for the duration of the sync (user-authorized only)
+
+This is a **user-gated action**. Do not run it without explicit approval — it temporarily disables the user's own automation. Present the commands and ask.
+
+```bash
+UID_=$(id -u)
+launchctl bootout gui/$UID_ ~/Library/LaunchAgents/ai.openclaw.gateway-watchdog.plist
+launchctl bootout gui/$UID_ ~/Library/LaunchAgents/ai.openclaw.gateway.plist
+
+# Now kill the GUI and confirm it stays dead
+pkill -f "Obsidian.app/Contents/MacOS/Obsidian"
+sleep 5
+pgrep -fl "Obsidian.app/Contents/MacOS/Obsidian" && echo "STILL ALIVE — abort sync" || echo "clear — proceed"
+```
+
+## Restore after sync
+
+Always restore the agents, even if the sync failed.
+
+```bash
+UID_=$(id -u)
+launchctl bootstrap gui/$UID_ ~/Library/LaunchAgents/ai.openclaw.gateway.plist
+launchctl bootstrap gui/$UID_ ~/Library/LaunchAgents/ai.openclaw.gateway-watchdog.plist
+launchctl list | grep openclaw   # confirm they are back
+```
+
+## Permanent removal (when `ob sync --continuous` is daemonised)
+
+Once the vault is served by a long-lived daemon (e.g. pm2-managed `ob sync --continuous` as set up on 2026-04-18), "bootstrap" is no longer a bounded window — it is the whole lifetime of the machine's role. In that world, re-spawning the Obsidian GUI at all on the headless host creates the race the incident report warned about.
+
+On 2026-04-18 the M1-pro `ai.openclaw.gateway` / `ai.openclaw.gateway-watchdog` plists were **deleted** (not just booted out) because the openclaw automation now runs as a separate, out-of-band service that does not depend on those agents. The vault-watcher and `local.backup-openclaw` plists were kept — they do not spawn Obsidian.
+
+```bash
+UID_=$(id -u)
+launchctl bootout gui/$UID_ ~/Library/LaunchAgents/ai.openclaw.gateway.plist 2>/dev/null
+launchctl bootout gui/$UID_ ~/Library/LaunchAgents/ai.openclaw.gateway-watchdog.plist 2>/dev/null
+rm -v ~/Library/LaunchAgents/ai.openclaw.gateway.plist \
+      ~/Library/LaunchAgents/ai.openclaw.gateway-watchdog.plist
+```
+
+Only take this step when:
+
+- the machine is explicitly the headless replica, and
+- the daily-note / vault automation that the gateway used to drive has an alternate runner (e.g. M3 GUI, or a standalone service), and
+- the user has confirmed the deletion.
+
+If any of those conditions is not met, keep the "suspend for the duration of the sync" pattern above instead.
+
+## Why this matters
+
+The 2026-04-17 incident investigation identified GUI-vs-headless race conditions as a contributing factor. Obsidian's background sync and `ob sync` both write to the same state database and the same set of files; if both run at once, one side's view of the world can lead the other to propagate "deletions" that are really in-flight edits.
+
+The safest setup is: **M3 has the GUI and runs sync through the GUI; M1 is headless and runs `ob sync`.** During bootstrap, even a transient Obsidian GUI on M1 is unacceptable.
+
+## Cross-platform note
+
+On Linux (no Obsidian GUI): this file does not apply.
+
+On Windows: the respawn surface is different (Task Scheduler, Startup folder, auto-relaunch via Electron). The general principle holds — find what is spawning Obsidian and suspend it for the sync window — but the exact commands differ.

--- a/skills/obsidian-sync/references/pm2-daemon.md
+++ b/skills/obsidian-sync/references/pm2-daemon.md
@@ -1,0 +1,101 @@
+# Daemonising `ob sync --continuous` with pm2
+
+Once the Stage -> Verify -> Promote sequence is complete on a headless replica, the last step is to run `ob sync --continuous` as a supervised daemon. pm2 is the chosen supervisor on this user's M1-pro: it survives logout, auto-restarts on crash, and integrates with the existing `pm2.beomsu.plist` at `/Library/LaunchDaemons/` so the whole stack comes back after a reboot without any sudo at sync time.
+
+Do not set up pm2 on a machine that still has the Obsidian GUI respawning — see `launchd-respawn.md` for the gateway/watchdog issue. A continuous daemon turns every transient GUI spawn into a GUI-vs-headless race.
+
+## One-time preconditions
+
+- `ob --version` reports a known-good version (currently the last known-good at the time of writing is the version immediately preceding the 2026-04-17 incident; see `cli-commands.md`).
+- `ob sync-status --path "<vault>"` reports `bidirectional` (Phase 4 promote complete).
+- `pm2 --version` works for the user (not root).
+- `/Library/LaunchDaemons/pm2.<user>.plist` is installed (one-time sudo step, done long before bootstrap).
+
+## Ecosystem file
+
+On M1-pro this lives at `~/.config/pm2/ob-sync-ataraxia.config.cjs`. Keep it in `~/.config/pm2/` rather than inside the vault so the vault stays pure-content.
+
+```javascript
+module.exports = {
+  apps: [{
+    name: "ob-sync-ataraxia",
+    script: "/opt/homebrew/bin/ob",
+    args: [
+      "sync",
+      "--path", "/Users/beomsu/Documents/01. Obsidian/Ataraxia",
+      "--continuous"
+    ],
+    interpreter: "none",          // ob is a Node shebang binary; let it interpret itself
+    cwd: "/Users/beomsu",
+    autorestart: true,
+    restart_delay: 5000,          // back off between crash-loops
+    max_restarts: 20,             // stop thrashing if something is fundamentally wrong
+    min_uptime: "30s",
+    kill_timeout: 10000,          // let ob finish a flush before SIGKILL
+    out_file: "/Users/beomsu/.pm2/logs/ob-sync-ataraxia-out.log",
+    error_file: "/Users/beomsu/.pm2/logs/ob-sync-ataraxia-err.log",
+    merge_logs: true,
+    time: true,                   // prefix every log line with a timestamp
+    env: {
+      NODE_ENV: "production",
+      PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+    }
+  }]
+};
+```
+
+Key choices and why:
+
+- `interpreter: "none"` — `ob` is already a Node shebang; pm2 should not try to wrap it in another Node process.
+- `restart_delay` + `min_uptime` + `max_restarts` — together they break a crash loop instead of burning CPU forever on a persistent error.
+- Logs under `~/.pm2/logs/` rather than the vault — log noise in the vault would confuse sync parity checks.
+- `time: true` — human-readable timestamps; "Fully synced" lines are the canonical heartbeat.
+
+## Start and persist
+
+```bash
+pm2 start ~/.config/pm2/ob-sync-ataraxia.config.cjs
+pm2 save                               # write ~/.pm2/dump.pm2
+pm2 startup launchd -u "$USER" --hp "$HOME"   # prints the sudo command to install boot persistence (already installed on this user's M1-pro, noop re-run is safe)
+```
+
+`pm2 save` writes the process list to `~/.pm2/dump.pm2`. When the system reboots, `/Library/LaunchDaemons/pm2.<user>.plist` launches pm2, which reads the dump and resurrects `ob-sync-ataraxia`. No sudo is needed at sync time after the one-time startup install.
+
+## Healthcheck
+
+A healthy daemon shows:
+
+```bash
+pm2 list | grep ob-sync-ataraxia
+# expected: status=online, restarts=0 or very low, uptime matching when you started it
+tail -n 3 ~/.pm2/logs/ob-sync-ataraxia-out.log
+# expected: recurring "Fully synced" lines every ~30 seconds
+```
+
+Warning signs:
+
+- `restarts` incrementing — open `~/.pm2/logs/ob-sync-ataraxia-err.log` before doing anything else.
+- `Fully synced` heartbeat stops — the vault is either disconnected or the server stopped responding; check network and `ob sync-status`.
+- RAM climbing past ~500 MB steady state for this vault size — restart with `pm2 restart ob-sync-ataraxia`.
+
+## Stop, restart, inspect
+
+```bash
+pm2 stop ob-sync-ataraxia         # pause; dump.pm2 still remembers it
+pm2 start ob-sync-ataraxia        # resume
+pm2 restart ob-sync-ataraxia      # full restart
+pm2 logs ob-sync-ataraxia --lines 200   # tail logs live
+pm2 delete ob-sync-ataraxia       # forget about it; remember to `pm2 save` after
+```
+
+If you change `ob-sync-ataraxia.config.cjs`, run `pm2 restart ob-sync-ataraxia --update-env` to pick up the new args/env, then `pm2 save`.
+
+## Rolling back
+
+pm2 is not a sync guard. If a bad `ob` release is deleting files, the guard is Layer 2 (pre-commit) plus the git safety tag from Phase 1 — the pm2 daemon should be stopped immediately:
+
+```bash
+pm2 stop ob-sync-ataraxia
+```
+
+Stopping pm2 does not undo whatever was already synced. The git safety tag is what gets you back.

--- a/skills/obsidian-sync/references/remote-m1-ops.md
+++ b/skills/obsidian-sync/references/remote-m1-ops.md
@@ -1,0 +1,115 @@
+# Driving M1-pro Sync Operations from the M3 SSOT
+
+All replica-side sync operations are authored on M3 (the SSOT) and executed on M1-pro via tailscale-backed SSH. This file is the command catalog.
+
+## Why SSOT-first
+
+- The vault and its git history live on M3. Changes authored on the replica shell do not appear in M3's plan/skill trace; the next agent session has no way to reconcile them.
+- Tailscale gives us a stable hostname (`m1-pro`) regardless of which network M1 is on. Every command below assumes it resolves via the tailnet.
+- The replica is treated as a cattle-class executor of SSOT-authored commands: no interactive editing, no in-place config changes, no ad-hoc one-off scripts that do not exist as files on M3.
+
+Exception: `ob sync-setup` needs a real TTY for the E2E password prompt. Run it in an interactive terminal on the replica (either physically or via an interactive `ssh -t m1-pro`), then immediately capture the resulting config into the audit trail on M3.
+
+## Preflight (run before any remote command)
+
+```bash
+# Network layer healthy?
+tailscale status | grep m1-pro
+tailscale ping --tsmp m1-pro | head -3
+```
+
+If either fails, fix tailscale before touching sync. See the `tailscale` skill for triage order.
+
+```bash
+# Service layer healthy?
+ssh m1-pro 'pm2 list | grep ob-sync-ataraxia'
+```
+
+Expect `status=online`, restarts=0 or very low. If offline or missing, do NOT run `sync-setup` or restart blindly — read logs first.
+
+## Inspect
+
+```bash
+# Daemon heartbeat
+ssh m1-pro 'tail -n 20 ~/.pm2/logs/ob-sync-ataraxia-out.log'
+# Expect recurring "Fully synced" every ~30s.
+
+# Recent errors
+ssh m1-pro 'tail -n 50 ~/.pm2/logs/ob-sync-ataraxia-err.log'
+
+# Live structured pm2 row (portable alternative to jlist)
+ssh m1-pro 'pm2 describe ob-sync-ataraxia | sed -n "1,40p"'
+
+# ob sync state
+ssh m1-pro 'ob sync-list-local'
+ssh m1-pro 'ob sync-status --path "/Users/beomsu/Documents/01. Obsidian/Ataraxia"'
+```
+
+## Restart and reload
+
+```bash
+# Full restart (picks up args/env changes in the ecosystem file)
+ssh m1-pro 'pm2 restart ob-sync-ataraxia --update-env && pm2 save'
+
+# Graceful stop (does not remove from dump.pm2)
+ssh m1-pro 'pm2 stop ob-sync-ataraxia'
+
+# Resume
+ssh m1-pro 'pm2 start ob-sync-ataraxia'
+
+# Re-read ecosystem file after edit (M3 drives via scp; never inline edit on M1)
+scp ~/config/pm2/ob-sync-ataraxia.config.cjs m1-pro:/Users/beomsu/.config/pm2/ob-sync-ataraxia.config.cjs
+ssh m1-pro 'pm2 reload ~/.config/pm2/ob-sync-ataraxia.config.cjs && pm2 save'
+```
+
+The `scp` step is what keeps the SSOT property intact: the ecosystem file's canonical copy lives on M3 (tracked in whatever config directory M3 uses), and the replica receives a mirror.
+
+## Mode changes (destructive — safety tag required)
+
+```bash
+# 1. Safety tag on both sides
+cd "/Users/beomsu/Documents/01. Obsidian/Ataraxia"
+git tag "safety/pre-mode-change-$(date -u +%Y%m%d-%H%M%S)"
+ssh m1-pro 'cd "/Users/beomsu/Documents/01. Obsidian/Ataraxia" && git tag "safety/pre-mode-change-$(date -u +%Y%m%d-%H%M%S)"'
+
+# 2. Stop the daemon before flipping mode — no concurrent reads/writes
+ssh m1-pro 'pm2 stop ob-sync-ataraxia'
+
+# 3. Flip mode
+ssh m1-pro 'ob sync-config --path "/Users/beomsu/Documents/01. Obsidian/Ataraxia" --mode pull-only'
+
+# 4. One-shot verify (non-continuous) before turning the daemon back on
+ssh m1-pro 'ob sync --path "/Users/beomsu/Documents/01. Obsidian/Ataraxia" 2>&1 | tee /tmp/ob-mode-verify.log'
+ssh m1-pro 'tail -n 30 /tmp/ob-mode-verify.log'
+
+# 5. Resume daemon only after verifying the diff is sane
+ssh m1-pro 'pm2 start ob-sync-ataraxia && pm2 save'
+```
+
+## Emergency stop (suspected bad release)
+
+```bash
+ssh m1-pro 'pm2 stop ob-sync-ataraxia'
+# Then roll back on M3 using the safety tag from the most recent Phase 1 preflight:
+cd "/Users/beomsu/Documents/01. Obsidian/Ataraxia"
+git reset --hard safety/pre-sync-<timestamp>
+```
+
+Stopping pm2 does not undo what already synced. The git safety tag does.
+
+## Patterns to avoid
+
+| Anti-pattern | Why it's bad |
+|---|---|
+| `ssh m1-pro` then typing `ob sync-config …` interactively | No audit trail on M3; next agent session cannot see the change |
+| Editing `~/.config/pm2/ob-sync-ataraxia.config.cjs` directly on M1 | SSOT drift — the replica's file diverges from the M3-tracked source |
+| `ssh m1-pro 'ob sync-setup …'` (non-interactive) | Fails silently at the password prompt; may leave partial config |
+| Running `pm2 restart` without `--update-env` after an ecosystem-file change | pm2 reuses the cached env; your change is invisible until a full delete+start |
+| `tailscale ssh m1-pro` for destructive ops | Works, but bypasses your `~/.ssh/config` which is where SSOT-level connection hardening lives — prefer plain `ssh m1-pro` |
+
+## Related
+
+- `pm2-daemon.md` — the ecosystem file itself, healthcheck signals, and rollback
+- `launchd-respawn.md` — why openclaw gateway plists were permanently removed on M1
+- `cli-commands.md` — `ob` flag reference
+- The `tailscale` skill — network-layer triage when `m1-pro` is unreachable

--- a/skills/openclaw/SKILL.md
+++ b/skills/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: Manage OpenClaw agent lifecycle on m1-pro — add/remove/modify age
 ## Overview
 Operate the OpenClaw multi-agent gateway running on m1-pro. OpenClaw is the "지휘자" (conductor) — it receives messages from Discord/Telegram/Slack, routes them to the appropriate AI agent, and returns responses. This skill captures personal operational context that generic docs do not cover. For standard CLI reference and setup instructions, query NotebookLM MCP with the OpenClaw documentation.
 
-Vault reference: `Ataraxia/50. AI/04 Workspaces/OpenClaw/` contains workspace definitions, agent protocols (AGENTS.md), and bootstrap guides (global.md).
+Vault reference: `Ataraxia/50. AI/04 Skills/openclaw/` is the live vault source for this skill package and its supporting references.
 
 ## When to Use
 - Adding, removing, or modifying agents (model change, identity update, skill assignment)
@@ -244,7 +244,7 @@ rm -rf ~/.openclaw/skills/<project-skill>/
 ```
 
 6. **Update vault references:**
-- Check `Ataraxia/50. AI/04 Workspaces/OpenClaw/openclaw.md` for agent references
+- Check `Ataraxia/50. AI/04 Skills/openclaw/references/operations.md` for agent references and operational notes
 - Update agent composition tables in terminology notes
 - Remove or archive related workspace notes
 
@@ -257,7 +257,7 @@ curl -s http://127.0.0.1:18789/health   # Gateway still healthy
 
 ## Reference
 
-For architecture diagrams, agent composition, session protocol, heartbeat vs cron, and troubleshooting (삽질 기록), see [references/operations.md](50.%20AI/04%20Skills/openclaw/references/operations.md).
+For architecture diagrams, agent composition, session protocol, heartbeat vs cron, and troubleshooting (삽질 기록), see [references/operations.md](references/operations.md).
 
 ## Common Rationalizations
 | Rationalization | Reality |

--- a/skills/tailscale/SKILL.md
+++ b/skills/tailscale/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: tailscale
+description: Use when you need to verify, repair, or operate Tailscale-mediated SSH from the Ataraxia SSOT (M3, Claude Code machine, Standalone .pkg install) to the headless replica (M1-pro, Homebrew install) before any remote sync, pm2, or OpenClaw command, when `m1-pro` appears offline or unreachable, or when a workflow depends on `m1-pro` being reachable before a dependent task can proceed. Also use when troubleshooting SSH-over-Tailscale, separating network-layer failures from service-layer failures, or documenting safe Serve/Funnel workflows. Never embed Tailscale IP addresses or tailnet domains in output.
+---
+
+# tailscale
+
+## Overview
+
+Tailscale is the transport layer between the Ataraxia SSOT (M3) and the headless replica (M1-pro). The `obsidian-sync` skill, any pm2 inspection of `ob-sync-ataraxia`, and OpenClaw remote commands all assume `ssh m1-pro` Just Works — which is only true when tailscale is healthy. Use this skill to verify that assumption and to triage when it doesn't hold.
+
+Two install methods are in play, and the difference matters when the daemon needs restarting:
+- **M3 (SSOT)** — Standalone `.pkg` install; daemon managed by the Tailscale.app.
+- **M1-pro (replica)** — Homebrew install; daemon managed by `brew services`.
+
+Reference files: `references/troubleshooting.md`, `references/install.md`.
+
+## When to Use
+
+- Before any `ssh m1-pro …` command authored from the SSOT (sync ops, pm2 inspect/restart, log tail)
+- When a workflow explicitly depends on the replica being reachable through the tailnet
+- When `m1-pro` appears offline, asleep, or SSH to it hangs
+- When SSH over Tailscale fails and you need to decide whether the fault is at the network layer or the service layer
+- When documenting Serve/Funnel workflows that must not leak private tailnet topology
+
+Do NOT use for:
+- Generic SSH problems that do not involve the tailnet
+- Public-facing Funnel design beyond the sync workflow's scope
+- Revealing Tailscale IP addresses (100.x.x.x), tailnet domain names, or machine-specific power-management routines
+
+## Process
+
+### 1. Check local status first (from the SSOT)
+
+```bash
+which tailscale || echo "tailscale CLI missing"
+tailscale status | head -20
+```
+
+Expect: the CLI is present, the local node is `connected`, and `m1-pro` appears in the peer list with an `idle` or `active` status (not `offline`).
+
+### 2. Verify remote reachability before dispatching any workflow
+
+```bash
+tailscale ping m1-pro | head -3
+```
+
+Expect: a `pong from m1-pro` line with a round-trip under a few hundred ms. If ping fails, DO NOT proceed to `ssh m1-pro` — the dependent workflow (`obsidian-sync`, pm2 ops) will hang and waste attempts.
+
+### 3. Separate network state from service state
+
+If `tailscale ping m1-pro` fails, the fault is at the tailnet layer. Triage on the replica's daemon (cannot reach it over tailscale, so use whatever out-of-band access exists, e.g., physical or iCloud screen share) via:
+- M1-pro (Homebrew): `brew services restart tailscale`
+- M3 (.pkg): toggle Tailscale.app off/on, or `sudo tailscale down && sudo tailscale up`
+
+If `tailscale ping m1-pro` succeeds but `ssh m1-pro` fails, the fault is at the service layer (sshd, keys, agent forwarding). Do not restart tailscale — fix ssh instead.
+
+### 4. Hand off to the dependent workflow
+
+Only after both checks pass, invoke the downstream skill:
+- Sync operations → `obsidian-sync` skill (`references/remote-m1-ops.md` for the command catalog)
+- pm2 inspection → `ssh m1-pro 'pm2 list | grep ob-sync-ataraxia'`
+- OpenClaw remote → the relevant OpenClaw workflow
+
+### 5. Serve or Funnel only after baseline connectivity is proven
+
+Never open a Serve or Funnel workflow before a fresh `tailscale status` + `tailscale ping <peer>` pass. Confirm the exposed service actually responds before treating the workflow as complete.
+
+## SSOT-first enforcement
+
+Every meaningful change in this two-machine setup is authored on M3 and executed over `ssh m1-pro`. That means:
+
+- Interactive ad-hoc sessions on M1 (`ssh m1-pro` then typing commands) leave no audit trail on the SSOT. Prefer one-shot `ssh m1-pro '<command>'` invocations so every remote action is visible in M3's transcript and skill history.
+- Config files (pm2 ecosystem, openclaw replacement scripts, anything else that governs the replica's behavior) live in tracked directories on M3 and are pushed to M1 via `scp`. Never edit them in place on M1.
+- The only legitimate interactive session on M1 is `ob sync-setup`, because the E2E password prompt requires a real TTY. Capture the resulting `~/.obsidian-headless/sync/<vaultId>/config.json` back to the SSOT audit trail immediately after.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The tailnet hostname is harmless." | Private node names and IP addresses reveal internal topology and must not appear in output. Use role labels (`m1-pro`, `m3-pro-max`) only. |
+| "If SSH fails, Tailscale must be broken." | SSH failure can originate at the network layer OR the remote service layer. Run `tailscale ping` before touching the tailscale daemon. |
+| "Both machines install the same way." | M3 uses Standalone `.pkg` (Tailscale.app); M1-pro uses Homebrew (`brew services`). Use the correct restart path per machine. |
+| "I'll just ssh into M1 and fix it interactively." | Kills the SSOT audit trail. Author the command on M3, run it as `ssh m1-pro '<cmd>'`, let the transcript carry the change. |
+| "Funnel once, then forget it." | Funnel exposes the replica to the public internet. Every Funnel workflow needs an explicit teardown step and a verification that the exposure is closed. |
+
+## Red Flags
+
+- Tailscale IP addresses (100.x.x.x) appear in output
+- The workflow jumps to SSH before confirming `tailscale ping` succeeds
+- Install method difference between M3 and M1-pro is ignored during daemon troubleshooting
+- Network and service debugging steps are mixed without clear branching
+- Interactive `ssh m1-pro` session used for a config change that belongs in a tracked file on M3
+- A Serve/Funnel was opened but there is no scripted teardown step
+
+## Verification
+
+After completing the skill's process, confirm:
+
+- [ ] `tailscale status` was run and both nodes appear as connected
+- [ ] `tailscale ping m1-pro` confirmed reachability before any `ssh m1-pro` was attempted
+- [ ] No Tailscale IP addresses (100.x.x.x) or tailnet domain names appear in output
+- [ ] Install-method differences (Standalone vs Homebrew) were accounted for when restarting the daemon
+- [ ] Network-layer and service-layer debugging were kept on separate branches
+- [ ] Remote commands were issued as one-shot `ssh m1-pro '<cmd>'`, not as interactive sessions on M1
+- [ ] If the caller was the `obsidian-sync` skill, control was handed off only after both ping and ssh-noop succeeded
+
+## Related
+
+- `obsidian-sync` skill — the primary downstream consumer; see its `references/remote-m1-ops.md` for the SSOT→replica command catalog
+- `references/troubleshooting.md` — failure-class triage order
+- `references/install.md` — public-safe install baseline

--- a/skills/tailscale/references/install.md
+++ b/skills/tailscale/references/install.md
@@ -1,0 +1,15 @@
+# Tailscale Install Reference
+
+## Goal
+Provide a public-safe installation baseline for Tailscale without embedding private machine assumptions.
+
+## Public-Safe Principles
+- Use the official Tailscale install flow for the target operating system.
+- Prefer the documented CLI path for automation instead of personal shell aliases.
+- Verify installation with a version or status command before continuing.
+
+## Minimal Flow
+1. Install Tailscale using the official package or installer for the target platform.
+2. Confirm the CLI is available.
+3. Authenticate through the supported login flow.
+4. Verify that the node appears in the tailnet before continuing to SSH, Serve, or Funnel tasks.

--- a/skills/tailscale/references/troubleshooting.md
+++ b/skills/tailscale/references/troubleshooting.md
@@ -1,0 +1,20 @@
+# Tailscale Troubleshooting Reference
+
+## Goal
+Provide a public-safe troubleshooting sequence for common Tailscale failures.
+
+## Triage Order
+1. Check whether the local client is installed and running.
+2. Check whether the node is authenticated.
+3. Check whether the remote node is reachable.
+4. Only then test SSH or exposed services.
+
+## Common Failure Classes
+- CLI missing or not on PATH
+- Client installed but disconnected
+- Auth expired or login required
+- Remote node offline or asleep
+- Network healthy but service-layer problem still unresolved
+
+## Rule
+Do not publish real hostnames, private IPs, tailnet domains, or personal SSH targets in examples.


### PR DESCRIPTION
Automated deploy from skill-deploy.

Highlights:
- New: obsidian-sync (SSOT-first rewrite of obsidian-sync-bootstrap)
- New: tailscale (SSOT→replica pattern, hands off to obsidian-sync)
- Update: openclaw SKILL.md