### PR TITLE
fix(obsidian-markdown): English-only description

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-skills",
   "description": "Personal Claude Code skill collection by Beomsu Koh",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "author": {
     "name": "Beomsu Koh"
   },

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-markdown
-description: Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties, and other Obsidian-specific syntax. Enforces the user's preferred formatting for notes -- headings limited to `##`-`####` (no H1, no H5+) and nested bullet lists limited to depth 3. Use when working with .md files in an Obsidian vault, when the user mentions wikilinks, callouts, frontmatter, tags, embeds, Obsidian notes, "옵시디언 노트", "콜아웃", "프론트매터", or when producing a note the user will read inside Obsidian.
+description: Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties, and other Obsidian-specific syntax. Enforces the user's preferred formatting for notes -- headings limited to `##`-`####` (no H1, no H5+) and nested bullet lists limited to depth 3. Use when working with .md files in an Obsidian vault, when the user mentions wikilinks, callouts, frontmatter, tags, embeds, or Obsidian notes, or when producing a note the user will read inside Obsidian.
 ---
 
 # Obsidian Flavored Markdown Skill


### PR DESCRIPTION
Remove Korean trigger phrases from description per vault guideline. Plugin 1.0.21 -> 1.0.22.