### PR TITLE
deploy: refresh 26 skills to 11. Skill Guideline schema (v1.0.25)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-skills",
   "description": "Personal Claude Code skill collection by Beomsu Koh",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "author": {
     "name": "Beomsu Koh"
   },

--- a/skills/book/SKILL.md
+++ b/skills/book/SKILL.md
@@ -9,6 +9,10 @@ description: Create or update book notes in the Obsidian vault with structured f
 
 Create or update book notes in `80. References/01 Book/`. Three source paths: URL-based (yes24.com), title-only (WebSearch fallback), or classic/historical text (Korean filename convention). Covers both creation and update workflows, including ToC skeleton injection and highlight-to-chapter mapping.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 
 - Use when the user provides a yes24.com URL or any bookstore link

--- a/skills/brian-note-challenge/SKILL.md
+++ b/skills/brian-note-challenge/SKILL.md
@@ -11,6 +11,10 @@ Fetch today's Brian Note Challenge email from Gmail via `gws` CLI, extract the c
 
 Detailed process reference: `[[Brian Note Challenge Daily (BNC)]]`
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 - The daily BNC email has arrived and needs to be ingested into the vault
 - A past BNC email was missed and needs retroactive ingestion

--- a/skills/clawhip/SKILL.md
+++ b/skills/clawhip/SKILL.md
@@ -8,7 +8,7 @@ description: Manage clawhip daemon operations on m1-pro — stale watch cleanup,
 ## Overview
 Operate the clawhip event-routing daemon running on m1-pro. This skill captures personal operational context (error patterns, workarounds, architecture decisions) that generic docs do not cover. For standard CLI reference and setup instructions, query NotebookLM MCP with the clawhip notebook instead.
 
-clawhip's role in the stack: it is the "무대 매니저" (stage manager) — it watches tmux sessions, git/github events, and agent lifecycle, then routes notifications to Discord. It does not execute code or make decisions; it observes and reports.
+clawhip's role in the stack: it is the stage manager (무대 매니저) — it watches tmux sessions, git/github events, and agent lifecycle, then routes notifications to Discord. It does not execute code or make decisions; it observes and reports.
 
 ## When to Use
 - Stale notifications firing on idle tmux sessions (e.g., `maestro-work pane 0.0 stale for 30m`)
@@ -117,7 +117,7 @@ clawhip send --channel <channel-id> --message "test: clawhip watch reconfigured"
 
 ## Reference
 
-For architecture diagrams, troubleshooting (삽질 기록), daemon lifecycle, and deliver safety details, see [references/operations.md](50.%20AI/04%20Skills/clawhip/references/operations.md).
+For architecture diagrams, troubleshooting (삽질 기록), daemon lifecycle, and deliver safety details, see [references/operations.md](references/operations.md).
 
 ## Common Rationalizations
 | Rationalization | Reality |

--- a/skills/defuddle/SKILL.md
+++ b/skills/defuddle/SKILL.md
@@ -9,6 +9,10 @@ description: Extract clean markdown from web articles and documentation pages us
 
 Defuddle (by kepano) extracts article content from web pages and returns clean markdown. It strips away navigation, ads, sidebars, and boilerplate — producing smaller, more focused content than a raw HTML fetch. It is the preferred web content extractor for readable pages in the vault workflow.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 
 - Fetching article, blog, or documentation content for summarization or note-taking

--- a/skills/deploy-quartz/deploy.sh
+++ b/skills/deploy-quartz/deploy.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Quartz Static Site Deployment Script
+# Copies content directly to Blog vault, builds, commits only content files.
+
+set -e
+
+# Load environment variables from Ataraxia vault
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VAULT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+if [ -f "$VAULT_DIR/.env" ]; then
+    source "$VAULT_DIR/.env"
+fi
+
+# Validate required environment variables
+if [ -z "$QUARTZ_REPO_PATH" ]; then
+    echo "Error: QUARTZ_REPO_PATH not set in .env"
+    exit 1
+fi
+
+if [ -z "$DEPLOY_SITE_URL" ]; then
+    echo "Error: DEPLOY_SITE_URL not set in .env"
+    exit 1
+fi
+
+# Validate paths exist
+if [ ! -d "$QUARTZ_REPO_PATH" ]; then
+    echo "Error: Quartz repository not found at $QUARTZ_REPO_PATH"
+    exit 1
+fi
+
+if [ ! -d "$QUARTZ_REPO_PATH/content" ]; then
+    echo "Error: content/ directory not found in $QUARTZ_REPO_PATH"
+    exit 1
+fi
+
+# Configuration
+BRANCH="${DEPLOY_GIT_BRANCH:-v5}"
+REMOTE="${DEPLOY_GIT_REMOTE:-origin}"
+CONTENT_DIR="$QUARTZ_REPO_PATH/content"
+
+echo "Starting Quartz deployment..."
+echo "Quartz repository: $QUARTZ_REPO_PATH"
+echo "Content directory: $CONTENT_DIR"
+
+# Step 1/3: Process Eagle images if needed
+EAGLE_FILES=$(grep -rl "file:///" "$CONTENT_DIR" --include="*.md" 2>/dev/null || true)
+if [ -n "$EAGLE_FILES" ] && [ -n "$EAGLE_LIBRARY_PATH" ] && [ -d "$EAGLE_LIBRARY_PATH/images" ]; then
+    echo ""
+    echo "Step 1/3: Processing Eagle images..."
+    node "$SCRIPT_DIR/process-eagle-images.mjs" "$CONTENT_DIR" "$EAGLE_LIBRARY_PATH" "$CONTENT_DIR/_attachments"
+else
+    echo ""
+    echo "Step 1/3: No Eagle images to process (skipped)"
+fi
+
+# Verify no Eagle paths remain
+EAGLE_COUNT=$(grep -r "file:///" "$CONTENT_DIR" --include="*.md" 2>/dev/null | grep -v "AGENTS.md" | wc -l | tr -d ' ' || echo 0)
+if [ "$EAGLE_COUNT" -ne 0 ]; then
+    echo "Warning: Found $EAGLE_COUNT Eagle file:/// paths in content"
+fi
+
+# Step 2/3: Build the site
+cd "$QUARTZ_REPO_PATH"
+echo ""
+echo "Step 2/3: Building Quartz site..."
+npx quartz build
+
+# Step 3/3: Commit and push (only content files)
+echo ""
+echo "Step 3/3: Committing and pushing to $REMOTE/$BRANCH..."
+
+# Only stage content files — never git add .
+git add content/ || true
+git add _attachments/ 2>/dev/null || true
+
+CHANGES=$(git diff --cached --name-only)
+if [ -z "$CHANGES" ]; then
+    echo "No changes to deploy. Site is already up to date."
+    exit 0
+fi
+
+git diff --cached --stat
+
+# Generate commit message from changed files
+ARTICLE_COUNT=$(echo "$CHANGES" | grep -cE "content/.*\.md$" || true)
+INDEX_COUNT=$(echo "$CHANGES" | grep -cE "content/.*index\.md$" || true)
+NEW_ARTICLES=$((ARTICLE_COUNT - INDEX_COUNT))
+
+if [ "$NEW_ARTICLES" -gt 0 ]; then
+    FIRST_ARTICLE=$(echo "$CHANGES" | grep -E "content/.*\.md$" | grep -v "index\.md" | head -1 | xargs basename | sed 's/\.md$//')
+    if [ "$NEW_ARTICLES" -eq 1 ]; then
+        COMMIT_MSG="feat: add $FIRST_ARTICLE"
+    else
+        COMMIT_MSG="feat: add $NEW_ARTICLES new articles"
+    fi
+else
+    IMAGE_CHANGES=$(echo "$CHANGES" | grep -c "_attachments" || true)
+    if [ "$IMAGE_CHANGES" -gt 0 ]; then
+        COMMIT_MSG="fix: update Eagle image paths"
+    else
+        COMMIT_MSG="fix: update content"
+    fi
+fi
+
+echo ""
+echo "Commit message: $COMMIT_MSG"
+git commit -m "$COMMIT_MSG"
+git push "$REMOTE" "$BRANCH"
+
+echo ""
+echo "Deployment completed successfully!"
+echo "Commit: $COMMIT_MSG"
+echo "Site: $DEPLOY_SITE_URL"
+echo ""
+echo "GitHub Actions will deploy the changes in a few moments"

--- a/skills/deploy-quartz/prepare-staging.sh
+++ b/skills/deploy-quartz/prepare-staging.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Load environment
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VAULT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+if [ -f "$VAULT_DIR/.env" ]; then
+    source "$VAULT_DIR/.env"
+fi
+
+# Validate Eagle library path
+if [ -z "$EAGLE_LIBRARY_PATH" ]; then
+    echo "Error: EAGLE_LIBRARY_PATH not set in .env"
+    echo ""
+    echo "Add the following to $VAULT_DIR/.env:"
+    echo "EAGLE_LIBRARY_PATH=\"/path/to/Ataraxia.library\""
+    exit 1
+fi
+
+if [ ! -d "$EAGLE_LIBRARY_PATH/images" ]; then
+    echo "Error: Eagle library not found at $EAGLE_LIBRARY_PATH"
+    echo "Expected directory: $EAGLE_LIBRARY_PATH/images"
+    exit 1
+fi
+
+# Paths
+SOURCE_DIR="$QUARTZ_REPO_PATH"
+STAGING_DIR="$SOURCE_DIR/.deploy-staging"
+ATTACHMENTS_DIR="$STAGING_DIR/_attachments"
+
+echo "Preparing deployment staging..."
+echo ""
+
+# Step 1: Create fresh staging directory
+echo "Cleaning previous staging..."
+rm -rf "$STAGING_DIR"
+mkdir -p "$ATTACHMENTS_DIR"
+
+# Step 2: Copy content to staging (exclude staging itself and _attachments)
+echo "Copying content to staging..."
+rsync -a \
+    --exclude='.deploy-staging' \
+    --exclude='_attachments' \
+    "$SOURCE_DIR/" "$STAGING_DIR/"
+
+echo ""
+
+# Step 3: Process Eagle images in staging
+echo "Processing Eagle images..."
+node "$SCRIPT_DIR/process-eagle-images.mjs" "$STAGING_DIR" "$EAGLE_LIBRARY_PATH" "$ATTACHMENTS_DIR"
+
+echo ""
+echo "Staging ready at: $STAGING_DIR"
+echo "  Original notes preserved with Eagle paths"
+echo "  Staging contains transformed content for deployment"

--- a/skills/deploy-quartz/process-eagle-images.mjs
+++ b/skills/deploy-quartz/process-eagle-images.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+
+// Parse command-line arguments
+const [stagingDir, eagleLibraryPath, attachmentsDir] = process.argv.slice(2);
+
+if (!stagingDir || !eagleLibraryPath || !attachmentsDir) {
+  console.error('Usage: process-eagle-images.mjs <staging-dir> <eagle-library-path> <attachments-dir>');
+  process.exit(1);
+}
+
+if (!fs.existsSync(attachmentsDir)) {
+  fs.mkdirSync(attachmentsDir, { recursive: true });
+}
+
+/**
+ * Recursively find all markdown files in a directory.
+ */
+function findMarkdownFiles(dir) {
+  const files = [];
+  const items = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const item of items) {
+    const fullPath = path.join(dir, item.name);
+    if (item.isDirectory()) {
+      files.push(...findMarkdownFiles(fullPath));
+    } else if (item.isFile() && item.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Extract Eagle image references from markdown content.
+ * Matches: ![alt](file:///...Ataraxia.library/images/...)
+ * Returns the full match, alt text, and absolute file path.
+ */
+function findEagleImages(content) {
+  const eaglePattern = /!\[([^\]]*)\]\((file:\/\/\/[^)]*Ataraxia\.library\/images\/[^)]+)\)/g;
+  const matches = [];
+
+  for (const match of content.matchAll(eaglePattern)) {
+    const fileUrl = match[2];
+    const filePath = decodeURIComponent(fileUrl.replace('file://', ''));
+
+    matches.push({
+      fullMatch: match[0],
+      altText: match[1],
+      imagePath: filePath,
+    });
+  }
+
+  return matches;
+}
+
+/**
+ * Generate a descriptive filename from alt text or Eagle ID.
+ */
+function generateDescriptiveFilename(altText, imagePath, index) {
+  const ext = path.extname(imagePath);
+
+  if (altText && altText.trim()) {
+    const slug = altText.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    return `${slug}${ext}`;
+  }
+
+  const eagleId = imagePath.match(/images\/([^/]+)\.info/)?.[1];
+  return `eagle-${eagleId || index}${ext}`;
+}
+
+/**
+ * Copy an Eagle image to the attachments directory.
+ * Returns the final filename on success, or null if the source is missing.
+ */
+function copyEagleImage(imagePath, newFilename) {
+  if (!fs.existsSync(imagePath)) {
+    console.warn(`  Warning: Source image not found: ${imagePath}`);
+    return null;
+  }
+
+  // Deduplicate filenames to avoid overwrites
+  let finalPath = path.join(attachmentsDir, newFilename);
+  let counter = 1;
+  while (fs.existsSync(finalPath)) {
+    const ext = path.extname(newFilename);
+    const base = path.basename(newFilename, ext);
+    finalPath = path.join(attachmentsDir, `${base}-${counter}${ext}`);
+    counter++;
+  }
+
+  try {
+    fs.copyFileSync(imagePath, finalPath);
+    const finalFilename = path.basename(finalPath);
+    console.log(`  Copied: ${finalFilename}`);
+    return finalFilename;
+  } catch (error) {
+    console.error(`  Failed to copy ${imagePath}: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Process a single markdown file: find Eagle images, copy them,
+ * and rewrite the markdown references to point to /_attachments/.
+ */
+function processMarkdownFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const eagleImages = findEagleImages(content);
+
+  if (eagleImages.length === 0) {
+    return false;
+  }
+
+  console.log(`\nProcessing: ${path.relative(stagingDir, filePath)}`);
+  console.log(`  Found ${eagleImages.length} Eagle image(s)`);
+
+  let newContent = content;
+  let changesApplied = false;
+
+  for (const [index, image] of eagleImages.entries()) {
+    const newFilename = generateDescriptiveFilename(image.altText, image.imagePath, index);
+    const copiedFilename = copyEagleImage(image.imagePath, newFilename);
+
+    if (copiedFilename) {
+      const newMarkdown = `![${image.altText}](/_attachments/${copiedFilename})`;
+      newContent = newContent.replace(image.fullMatch, newMarkdown);
+      changesApplied = true;
+    }
+  }
+
+  if (changesApplied) {
+    fs.writeFileSync(filePath, newContent, 'utf-8');
+    console.log(`  Updated markdown file`);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Main: scan all markdown files in staging and process Eagle images.
+ */
+function main() {
+  console.log('Scanning for Eagle image paths in staging...\n');
+
+  const markdownFiles = findMarkdownFiles(stagingDir);
+  let filesProcessed = 0;
+
+  for (const file of markdownFiles) {
+    if (processMarkdownFile(file)) {
+      filesProcessed++;
+    }
+  }
+
+  console.log(`\nEagle processing complete. Processed ${filesProcessed} file(s)`);
+
+  if (filesProcessed === 0) {
+    console.log('  No Eagle images found in staging.');
+  }
+}
+
+main();

--- a/skills/generate-daily-roundup/SKILL.md
+++ b/skills/generate-daily-roundup/SKILL.md
@@ -6,7 +6,12 @@ description: Use when you need to synthesize a day of source notes into a daily 
 # generate-daily-roundup
 
 ## Overview
+
 Generate a daily roundup by synthesizing the day’s vault activity into a thematic narrative. Sources are discovered across `15. Work/01 Project/`, `15. Work/02 Area/`, `80. References/`, and the daily note at `10. Time/01 Daily Notes/YYYY-MM-DD.md`. Output goes into a section of that daily note. Quality targets from `references/quality-standard.md`: 4+ sources, 8+ validated wikilinks, 2+ cross-source connections, 60+ output lines.
+
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
 
 ## When to Use
 - Use when the user wants a daily synthesis across notes collected during a single day

--- a/skills/generate-weekly-roundup/SKILL.md
+++ b/skills/generate-weekly-roundup/SKILL.md
@@ -9,6 +9,10 @@ description: Use when you need to synthesize a week of activity into a weekly ro
 
 Generate a weekly roundup by reading each day's GDR output as the primary distilled source, supplemented by raw daily notes for days without a GDR. The output is not a summary of summaries — it is a cross-day pattern analysis that names what recurred, what failed repeatedly, and what direction the week's arc implies. The synthesis is written as its own note at `50. AI/03 Roundup/Weekly/YYYY-MM-DD~YYYY-MM-DD - GWR.md`, and the weekly note's `roundup:` frontmatter field is set to point at it — so the weekly note stays a plan/index surface and the GWR note carries the synthesis, exactly like daily notes + GDR notes.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 
 - Use when the user wants a weekly synthesis across multiple days

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 A 4-stage pipeline that turns one URL into a vault note at 「W를 찾아서」 quality:
 
-1. **Stage 1 — Raw** (this agent): defuddle → 공명 → terminology substitute (raw Transcript/Content only) → save raw → spawn Stage 2 → **exit**
+1. **Stage 1 — Raw** (this agent): defuddle → resonance (공명) → terminology substitute (raw Transcript/Content only) → save raw → spawn Stage 2 → **exit**
 2. **Stage 2 — Process** (fresh agent, Task tool): rewrite → mermaid → structural DoD self-check → terminology substitute (full processed body) → save → spawn Stage 3; on APPROVE spawn Stage 4
 3. **Stage 3 — Review** (fresh agent, read-only): transcript coverage audit → APPROVE / ITERATE / REJECT
 4. **Stage 4 — Terminology backfill** (fresh orchestrator, spawned by Stage 2 after APPROVE): source-idempotency check → fan-out parallel `/terminology` subagents → `50. AI/02 Terminologies/`
@@ -18,6 +18,10 @@ A 4-stage pipeline that turns one URL into a vault note at 「W를 찾아서」 
 **SSOT chain.** Raw note holds the web URL (`source_url:`). Processed note holds a full-path wikilink to the raw note (e.g., `source: "[[80. References/05 Videos/TITLE|TITLE]]"`). The full path is required because raw and processed notes share the same filename stem — a bare `[[TITLE]]` would resolve ambiguously. Reviewer reads both. Raw is immutable; processed is regenerable.
 
 **Why 3 stages?** Stage 1 and 2 run in separate contexts so the rewriter gets a focused prompt, not a conversation history. Stage 3 is a fresh agent so the reviewer cannot self-approve its own draft.
+
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
 
 ## When to Use
 
@@ -36,7 +40,7 @@ Do NOT use for:
 Follow `references/stage1-raw.md` in detail. Summary:
 
 1. Detect URL type (video vs article)
-2. Interview the user briefly (1-3 exchanges) for 공명
+2. Interview the user briefly (1-3 exchanges) for resonance (공명)
 3. Validate the URL (https scheme, no shell metacharacters); run `defuddle parse "URL" --md -o /tmp/ingest-defuddle-output.md`; delete the temp file after reading
 4. Load the correct template from `assets/`:
    - Video: `assets/video-raw.template.md`
@@ -59,11 +63,11 @@ Spawn a fresh agent with:
       * <skill>/references/stage2-process.md
       * <skill>/references/golden-patterns.md
       * <skill>/assets/video-processed.template.md   (or article-processed)
-  - Task: Read raw_path, rewrite into 문어체 processed note, save to 50. AI/.
+  - Task: Read raw_path, rewrite into a 문어체 (formal written Korean) processed note, save to 50. AI/.
   - Inputs:
       raw_path: /absolute/path/to/raw.md
       content_type: video | article
-      user_intent: <the 공명 text from Stage 1>
+      user_intent: <the resonance text from Stage 1>
       iteration: 1
   - When done, spawn the Stage 3 reviewer per <skill>/references/stage2-process.md Step 8.
 ```

--- a/skills/ingest/agents/reviewer.md
+++ b/skills/ingest/agents/reviewer.md
@@ -1,0 +1,86 @@
+---
+name: ingest-reviewer
+description: Read-only reviewer that judges a processed ingest note against the golden-patterns rubric. Invoked by the ingest skill after Stage 2 via the Task tool. Returns a structured verdict (APPROVE / ITERATE / REJECT) with evidence. Never writes or edits files.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+# ingest-reviewer
+
+You are the quality gate for a 4-stage ingest pipeline (Raw → Process → Review → Terminology Backfill). A Stage 2 agent just produced a processed note. Your job is to judge whether it reaches **「W를 찾아서」급** quality before the pipeline hands off to Stage 4.
+
+## Your boundary
+
+- You are READ-ONLY. You MUST NOT Write, Edit, or modify any file.
+- You only return a structured verdict. The caller acts on it.
+- You are a fresh context — you did not write the note you are reviewing. Be honest.
+
+## Inputs you receive from the caller
+
+- `processed_path` — absolute path to the processed note (e.g. `.../50. AI/05 Videos/TITLE.md`)
+- `raw_path` — absolute path to the raw note the processed note was derived from
+- `iteration` — 1, 2, or 3 (max 3 rewrites before escalation)
+
+## Rubric (SSOT)
+
+Read the rubric from `references/golden-patterns.md` relative to this skill. It defines quality for BOTH video and article outputs. Apply the Common section + the type-specific section (`type: video` or `type: article` in the processed note's frontmatter).
+
+## Your single check: transcript coverage
+
+Read the raw note's `## Transcript` section (video) or `## Content` section (article).
+
+### Sampling
+
+N = min(20, total_sentences // 3), with a floor of N = 5.
+
+- Estimate total_sentences as the sentence count in the Transcript/Content section.
+  Use: grep -c '[.!?]' raw_path as a rough count; adjust manually for obvious
+  over/under-counting (timestamps contain many periods).
+- Select N sentences evenly spaced (indices 0, total//N, 2*total//N, ...) — not
+  front-loaded.
+
+### For each sampled sentence
+
+Search the processed note's body for a 문어체 counterpart:
+- Accept semantic equivalence: paraphrase, restructured clause, reordered words.
+- Accept merging: "1 prose sentence covering 2 source sentences" counts as COVERED
+  for BOTH source sentences.
+- Do NOT require verbatim match.
+- Record: sentence index, first 10 words of source sentence, COVERED / MISSING.
+
+### Verdict thresholds
+
+- APPROVE:  ratio >= 0.90
+- ITERATE:  0.70 <= ratio < 0.90  (FEEDBACK must list every MISSING sentence)
+- REJECT:   ratio < 0.70          (fundamental rewriting error; surface to user)
+
+## Verdict format
+
+Return exactly this structure as your final output:
+
+VERDICT: APPROVE | ITERATE | REJECT
+
+EVIDENCE:
+1. Coverage: <ratio> (N=<sample size>, <covered>/<total sampled>)
+   Missed sentences (if any):
+   - [idx <N>] "<first 10 words of source sentence>..." — MISSING
+
+FEEDBACK (if not APPROVE):
+- Re-examine sentences at indices: <list>
+- <specific rewriting guidance if a pattern is detectable>
+
+## Verdict rules
+
+- APPROVE  — coverage ratio >= 0.90, or only cosmetic issues remain
+- ITERATE  — 0.70 <= ratio < 0.90; FEEDBACK lists every missed sentence by index
+- REJECT   — ratio < 0.70, or fundamental problems (bad raw, corrupt input)
+- If iteration == 3 and verdict is still ITERATE: escalate to REJECT
+
+## Anti-rationalizations
+
+| Excuse | Why it's wrong |
+|---|---|
+| "The note reads nicely, approve it." | Nice reading is not the rubric. Sample sentences and compute the ratio. |
+| "I need verbatim match to be sure." | Semantic equivalence is the standard. 문어체 rewrite is supposed to paraphrase. |
+| "5 samples is enough for a short video." | Use N = min(20, total_sentences // 3), floor 5. Report N explicitly. |
+| "Coverage looks high — I don't need to list missed sentences." | ITERATE requires listing every MISSING sentence by index. Without the list, Stage 2 cannot fix them. |

--- a/skills/ingest/agents/reviewer.yaml
+++ b/skills/ingest/agents/reviewer.yaml
@@ -1,0 +1,72 @@
+name: ingest-reviewer
+description: >
+  Read-only reviewer that judges a processed ingest note against the golden-patterns rubric.
+  Invoked by the ingest skill after Stage 2. Returns a structured verdict (APPROVE / ITERATE / REJECT)
+  with evidence. Never writes or edits files.
+
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+
+model: opus
+
+system_prompt: |
+  You are the quality gate for a 4-stage ingest pipeline (Raw → Process → Review →
+  Terminology Backfill). A Stage 2 agent just produced a processed note. Your job is to
+  judge whether it reaches 「W를 찾아서」급 quality before the pipeline hands off to Stage 4.
+
+  Boundary:
+    - You are READ-ONLY. You MUST NOT Write, Edit, or modify any file.
+    - You only return a structured verdict. The caller acts on it.
+    - You are a fresh context — you did not write the note you are reviewing. Be honest.
+
+  Inputs from caller:
+    - processed_path: absolute path to the processed note
+    - raw_path: absolute path to the raw note
+    - iteration: 1, 2, or 3 (max 3 rewrites before escalation)
+
+  Rubric SSOT:
+    Read `references/golden-patterns.md` relative to this skill. It defines quality for BOTH
+    video and article outputs. Apply the Common section plus the type-specific section
+    (type: video or type: article in the processed note's frontmatter).
+
+required_checks:
+  - name: transcript_coverage
+    description: >
+      Sample N=min(20, total_sentences//3) sentences (floor 5) evenly spaced from raw
+      Transcript/Content section. For each, find a semantic 문어체 counterpart in the
+      processed body. Accept paraphrase and merged-sentence coverage; do not require
+      verbatim match. APPROVE >= 0.90. ITERATE 0.70-0.90 with FEEDBACK listing every
+      missed sentence by index. REJECT < 0.70.
+
+verdict_format: |
+  Return exactly this structure as your final output:
+
+  VERDICT: APPROVE | ITERATE | REJECT
+
+  EVIDENCE:
+  1. Coverage: <ratio> (N=<sample size>, <covered>/<total sampled>)
+     Missed sentences (if any):
+     - [idx <N>] "<first 10 words of source sentence>..." — MISSING
+
+  FEEDBACK (if not APPROVE):
+  - Re-examine sentences at indices: <list>
+  - <specific rewriting guidance if a pattern is detectable>
+
+verdict_rules:
+  APPROVE: coverage ratio >= 0.90, or only cosmetic issues remain
+  ITERATE: 0.70 <= ratio < 0.90; FEEDBACK lists every missed sentence
+  REJECT: ratio < 0.70, or fundamental problems
+  escalation: if iteration == 3 and verdict is still ITERATE, escalate to REJECT
+
+anti_rationalizations:
+  - excuse: "The note reads nicely, approve it."
+    rebuttal: "Nice reading is not the rubric. Sample sentences and compute the ratio."
+  - excuse: "I need verbatim match to be sure."
+    rebuttal: "Semantic equivalence is the standard. 문어체 rewrite is supposed to paraphrase."
+  - excuse: "5 samples is enough for a short video."
+    rebuttal: "Use N = min(20, total_sentences // 3), floor 5. Report N explicitly."
+  - excuse: "Coverage looks high — I don't need to list missed sentences."
+    rebuttal: "ITERATE requires listing every MISSING sentence by index. Without the list, Stage 2 cannot fix them."

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -17,6 +17,10 @@ argument-hint: "[--guideline-dir <path>] [--phase inspect|execute|review] [--sco
 
 `lint` is the vault's three-phase guideline-compliance engine. It reads guideline files under `90. Settings/01 Guideline/` (plus depth-1 and depth-2 `AGENTS.md` files) on every invocation, runs bundled inspection scripts to surface all mechanically-checkable violations, then applies safe auto-fixes through the Obsidian eval engine to preserve wikilinks and backlinks. It is not a knowledge-enrichment or wiki-generation tool — that concern belongs to the future `wiki` skill.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 
 **Use when:**

--- a/skills/lint/evals/evals.json
+++ b/skills/lint/evals/evals.json
@@ -1,0 +1,47 @@
+{
+  "skill_name": "lint",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Run a full vault audit and show me all frontmatter violations.",
+      "expected_output": "Phase 1 dashboard showing violation counts by category, auto-fixable vs judgment, before any fixes are applied.",
+      "files": [],
+      "expectations": [
+        "The skill read guideline files from 90. Settings/01 Guideline/ before running scripts",
+        "The skill ran verify-eval-engine.sh preflight before any inspection",
+        "The skill ran all 6 inspect-*.sh scripts (inspect-frontmatter, inspect-tags, inspect-types, inspect-moc, inspect-yaml, inspect-overview)",
+        "The skill presented a Vault Health Dashboard with violation counts per category",
+        "The skill did NOT apply any fixes without user confirmation",
+        "The skill did NOT hard-code any guideline rule values in its output"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Fix all YAML delimiter errors in my vault. Use dry-run first.",
+      "expected_output": "Dry-run diff showing files with ----+ delimiter violations, then actual fixes applied after confirmation, then Phase 3 re-inspection showing delta.",
+      "files": [],
+      "expectations": [
+        "The skill ran fix-yaml-delimiters.sh with --dry-run first",
+        "The skill presented a structured diff in the format: [DRY-RUN] Would fix: <file> / changes: oversized_delimiter",
+        "The skill waited for user confirmation before running without --dry-run",
+        "The skill did NOT call obsidian eval or vault.modify() during the dry-run phase",
+        "After applying, the skill re-ran inspect-yaml.sh to show before/after delta",
+        "The skill did NOT write raw YAML with sed or awk"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Check if the obsidian-linter plugin is ready and scan the 50. AI folder for tag violations.",
+      "expected_output": "verify-eval-engine.sh 4-check report, then inspect-tags.sh output scoped to 50. AI/, with no fixes applied.",
+      "files": [],
+      "expectations": [
+        "The skill ran verify-eval-engine.sh and reported all 4 check results",
+        "The skill passed a --scope argument limiting inspection to the 50. AI/ folder",
+        "The skill ran inspect-tags.sh with the scope-limited vault path",
+        "The skill reported tag violations without applying any fixes",
+        "The skill did NOT scan the entire vault when a scope was specified",
+        "The skill did NOT apply any fixes during this inspect-only invocation"
+      ]
+    }
+  ]
+}

--- a/skills/make-skill/SKILL.md
+++ b/skills/make-skill/SKILL.md
@@ -9,26 +9,30 @@ description: Author a new agent-skill for this vault, OR update an existing one 
 
 Detect create vs update mode, collect a change-reason, draft with a writer subagent that reads the Skill Guideline at runtime, review once with a dedicated reviewer subagent, commit with a Change Log entry appended to the vault stub `{skill-name}.md` (SKILL.md itself never carries the Change Log). Pipeline templates live in `references/pipeline.md`.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 
 - "/make-skill", "make a skill", "스킬 만들자", "skillify this", "update this skill", "fix this skill"
 - User wants to capture a repeated workflow or turn a prompt/template into a skill
 
-**NOT for:** prompts under `70. Collections/02 Prompt/` (process SSOT) or templates under `90. Settings/02 Templates/` (format SSOT).
+**NOT for:** prompts under `70. Collections/02 Prompt/` (process SSOT), templates under `90. Settings/02 Templates/` (format SSOT), or skill packages outside `50. AI/04 Skills/Obsidian/` (the vault SSOT root for skills).
 
 ## Dependencies (Check Before Any Work)
 
 Verify both in parallel; abort with a clear error if either fails.
 
 1. `test -f ~/.claude/plugins/marketplaces/anthropic-agent-skills/skills/skill-creator/SKILL.md` — if missing, tell user to install `anthropic-agent-skills` and stop.
-2. `test -f "/Users/beomsu/Documents/01. Obsidian/Ataraxia/90. Settings/01 Guideline/Skill Guideline.md"` — if missing, stop and ask user to restore.
+2. `test -f "/Users/beomsu/Documents/01. Obsidian/Ataraxia/90. Settings/01 Guideline/11. Skill Guideline.md"` — if missing, stop and ask user to restore.
 
 ## Workflow
 
 ### 1. Detect mode and collect change-reason
 
 ```bash
-SKILL_DIR="/Users/beomsu/Documents/01. Obsidian/Ataraxia/50. AI/04 Skills/<skill-name>"
+SKILL_DIR="/Users/beomsu/Documents/01. Obsidian/Ataraxia/50. AI/04 Skills/Obsidian/<skill-name>"
 test -f "$SKILL_DIR/SKILL.md" && mode=update || mode=create
 ```
 
@@ -38,7 +42,7 @@ test -f "$SKILL_DIR/SKILL.md" && mode=update || mode=create
 
 ### 2. Writer subagent invocation
 
-Invoke the writer as specified in `references/pipeline.md § Writer Task`. The writer MUST read `Ataraxia/90. Settings/01 Guideline/Skill Guideline.md` inside its own context before authoring any content. The writer handles the create/update branch and Change Log management per spec.
+Invoke the writer as specified in `references/pipeline.md § Writer Task`. The writer MUST read `Ataraxia/90. Settings/01 Guideline/11. Skill Guideline.md` inside its own context before authoring any content. The writer handles the create/update branch and Change Log management per spec.
 
 ### 3. Reviewer subagent invocation
 
@@ -68,19 +72,19 @@ For objectively verifiable outputs, run Anthropic's eval loop from `skill-creato
 - Missing `{skill-name}.md` stub, or missing `publish: true` on a deploy-intended skill
 - `description` summarizes workflow steps or lacks Korean triggers when user runs Korean workflow
 - Change Log section missing or schema-violating after writer pass
-- Writer subagent called without an explicit instruction to read Skill Guideline.md in its own context
+- Writer subagent called without an explicit instruction to read `11. Skill Guideline.md` in its own context
 
 ## Verification
 
 - [ ] Both dependency checks returned OK before any file was written
 - [ ] Mode correctly set to `create` or `update` before writer invocation.
 - [ ] In update mode: `<change-reason>` collected (argument or AskUserQuestion) before writer called.
-- [ ] Writer subagent system prompt included explicit Skill Guideline.md read instruction.
+- [ ] Writer subagent system prompt included explicit `11. Skill Guideline.md` read instruction.
 - [ ] Reviewer verdict was `approve` or `request_changes`; if neither, named warning logged and current draft committed.
 - [ ] `## Change Log` section present at end of committed `{skill-name}.md` vault stub (never in SKILL.md).
 - [ ] First (or only) Change Log entry in the stub matches `^\- \[\[[0-9]{4}-[0-9]{2}-[0-9]{2}\]\]`.
 - [ ] Post-commit grep gate ran against the stub and either passed silently or emitted `WARN: Change Log schema violation detected`.
-- [ ] Directory created at `50. AI/04 Skills/<skill-name>/` (create mode)
+- [ ] Directory created at `50. AI/04 Skills/Obsidian/<skill-name>/` (create mode)
 - [ ] `SKILL.md` frontmatter `name` matches the directory name
 - [ ] In update mode: original `name` frontmatter preserved exactly
 - [ ] `description` covers *what* + *when* and contains the real user phrases

--- a/skills/make-skill/references/pipeline.md
+++ b/skills/make-skill/references/pipeline.md
@@ -15,7 +15,7 @@ Task(
     and a compliant vault stub ({SKILL_DIR}/<skill-name>.md).
 
     MANDATORY: Before writing anything, read the full Skill Guideline at:
-      Ataraxia/90. Settings/01 Guideline/Skill Guideline.md
+      Ataraxia/90. Settings/01 Guideline/11. Skill Guideline.md
 
     Mode: {create | update}
     Target SKILL.md: {SKILL_DIR}/SKILL.md
@@ -53,11 +53,11 @@ Task(
 
     SKILL.md path: {SKILL_DIR}/SKILL.md
     Vault stub path: {SKILL_DIR}/<skill-name>.md
-    Guideline path: Ataraxia/90. Settings/01 Guideline/Skill Guideline.md
+    Guideline path: Ataraxia/90. Settings/01 Guideline/11. Skill Guideline.md
 
     Checklist (evaluate ONLY these):
     1. Guideline compliance: does structure, naming, and section order in SKILL.md match
-       Skill Guideline.md? SKILL.md must NOT contain ## Change Log.
+       `11. Skill Guideline.md`? SKILL.md must NOT contain ## Change Log.
     2. English-only body in SKILL.md: is every non-example-string line in English?
     3. Change Log schema in the vault stub: does ## Change Log exist at the end of
        {SKILL_DIR}/<skill-name>.md, with entries matching

--- a/skills/obsidian-bases/.deploy_scope
+++ b/skills/obsidian-bases/.deploy_scope
@@ -1,1 +1,1 @@
-xia
+global

--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -9,6 +9,10 @@ description: Write, read, and optimize Obsidian Bases (`.base` files and `base` 
 
 Obsidian Bases (1.9+) turn the vault into a queryable dataset. Every `.base` file is YAML conforming to a fixed schema; embedded bases use a ` ```base ` code block with the same YAML. Getting `groupBy` and `sort` right is the difference between a base that *lists rows* and a base that *gives the reader a mental model* of the project.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 
 - Creating or editing a `.base` file under `90. Settings/05 Bases/`

--- a/skills/obsidian-bases/references/functions.md
+++ b/skills/obsidian-bases/references/functions.md
@@ -6,19 +6,19 @@ permalink: bases/functions
 publish: true
 ---
 
-Functions are used in [[Introduction to Bases|Bases]] to manipulate data from [[properties]] in [[Views#Filters|filters]] and [[formulas]]. See the [[Bases syntax|bases syntax]] reference to learn more about how you can use functions.
+Functions are used in [[Introduction to Bases|Bases]] to manipulate data from [[PROPERTIES]] in [[views#Filters|filters]] and [[formulas]]. See the [[Bases syntax|bases syntax]] reference to learn more about how you can use functions.
 
-Aside from [[Functions#Global|Global]] functions, most functions depend on the type of value you want to modify:
+Aside from [[functions#Global|Global]] functions, most functions depend on the type of value you want to modify:
 
-- [[Functions#Any|Any]]
-- [[Functions#Date|Date]]
-- [[Functions#String|String]]
-- [[Functions#Number|Number]]
-- [[Functions#List|List]]
-- [[Functions#Link|Link]]
-- [[Functions#File|File]]
-- [[Functions#Object|Object]]
-- [[Functions#Regular expression|Regular expression]]
+- [[functions#Any|Any]]
+- [[functions#Date|Date]]
+- [[functions#String|String]]
+- [[functions#Number|Number]]
+- [[functions#List|List]]
+- [[functions#Link|Link]]
+- [[functions#File|File]]
+- [[functions#Object|Object]]
+- [[functions#Regular expression|Regular expression]]
 
 ## Global
 

--- a/skills/obsidian-bases/references/syntax.md
+++ b/skills/obsidian-bases/references/syntax.md
@@ -9,7 +9,7 @@ publish: true
 
 When you [[Create a base|create a base]] in Obsidian, it is saved as a `.base` file. Bases are typically edited using the app interface, but the syntax can also be edited manually, and embedded in a code block.
 
-The [[Introduction to Bases|Bases]] syntax defines [[Views]], filters, and [[formulas]]. Bases must be valid YAML conforming to the schema defined below.
+The [[Introduction to Bases|Bases]] syntax defines [[views]], filters, and [[formulas]]. Bases must be valid YAML conforming to the schema defined below.
 
 ## Example
 
@@ -92,7 +92,7 @@ These two sections are functionally equivalent and when evaluating for a view th
 The `filters` section contains either a single filter statement as a string, or a recursively defined filter object. Filter objects may contain one of `and`, `or`, or `not`. These keys are a heterogeneous list of other filter objects or filter statements in strings. A filter statement is a line which evaluates to truthy or falsey when applied to a note. It can be one of the following:
 
 - A basic comparison using standard arithmetic operators.
-- A function. A variety of [[Functions]] are built-in, and plugins can add additional functions.
+- A function. A variety of [[functions]] are built-in, and plugins can add additional functions.
 
 The syntax and available functions for filters and formulas are the same.
 
@@ -106,7 +106,7 @@ formulas:
   ppu: "(price / age).toFixed(2)"
 ```
 
-Formula properties support basic arithmetic operators and a variety of built-in [[Functions]]. In the future, plugins will be able to add functions for use in formulas.
+Formula properties support basic arithmetic operators and a variety of built-in [[functions]]. In the future, plugins will be able to add functions for use in formulas.
 
 You can reference properties in different ways depending on their type:
 
@@ -206,7 +206,7 @@ views:
 - `groupBy` specifies a property and sort direction. The value of the specified property for each row is used to place the row into groups.
 - `summaries` maps property names to a named summary. Summaries perform an aggregation on the property across all rows.
 
-[[Views]] can add additional data to store any information needed to maintain state or properly render, however plugin authors should take care to not use keys already in use by the core Bases plugin. As an example, a table view may use this to limit the number of rows or to select which column is used to sort rows and in which direction. A different view type such as a map could use this for mapping which property in the note corresponds to the latitude and longitude and which property should be displayed as the pin title.
+[[views]] can add additional data to store any information needed to maintain state or properly render, however plugin authors should take care to not use keys already in use by the core Bases plugin. As an example, a table view may use this to limit the number of rows or to select which column is used to sort rows and in which direction. A different view type such as a map could use this for mapping which property in the note corresponds to the latitude and longitude and which property should be displayed as the pin title.
 
 In the future, API will allow views to read and write these values, allowing the view to build its own interface for configuration.
 
@@ -220,7 +220,7 @@ There are three kinds of properties used in bases:
 
 ### Note properties
 
-[[Properties|Note properties]] are only available for Markdown files, and are stored in the YAML frontmatter of each note. These properties can be accessed using the format `note.author` or simply `author` as a shorthand.
+[[PROPERTIES|Note properties]] are only available for Markdown files, and are stored in the YAML frontmatter of each note. These properties can be accessed using the format `note.author` or simply `author` as a shorthand.
 
 ### File properties
 
@@ -285,7 +285,7 @@ Dates can be modified by adding and subtracting durations. Duration units accept
 
 To modify or offset Date objects, use the `+` or `-` operator with a duration string. For example, `date + "1M"` adds 1 month to the date, while `date - "2h"` subtracts 2 hours from the date.
 
-The global [[Functions|function]] `today()` can be used to get the current date, and `now()` can be used to get the current date with time.
+The global [[functions|function]] `today()` can be used to get the current date, and `now()` can be used to get the current date with time.
 
 - `now() + "1 day"` returns a datetime exactly 24 hours from the time of execution.
 - `file.mtime > now() - "1 week"` returns `true` if the file was modified within the last week.
@@ -319,7 +319,7 @@ Boolean operators can be used to combine or invert logical values, resulting in 
 
 ## Functions
 
-See the [[Functions|list of functions]] that can be used in formulas and [[Views|filters]].
+See the [[functions|list of functions]] that can be used in formulas and [[views|filters]].
 
 ## Types
 
@@ -335,13 +335,13 @@ Strings, numbers, and booleans are "primitive" values which do not require a fun
 
 ### Dates and durations
 
-Dates represent a specific date, or a date and time depending on the function used to create them, or that type that has been assigned to the [[Properties|property]].
+Dates represent a specific date, or a date and time depending on the function used to create them, or that type that has been assigned to the [[PROPERTIES|property]].
 
 - To construct a date, use the `date` function, for example `date("2025-01-01 12:00:00")`
 - To modify a date, add or remove a duration, for example `now() + "1 hour"` or `today() + "7d"`
 - Compare dates using comparison operators (e.g. `>` or `<`) and arithmetic operators (for example, `(now() + "1d") - now()` returns `86400000` milliseconds.)
 - To extract portions of a date, use the available fields (`now().hour`), or a convenience function (`now.time()`).
-- Many other [[Functions|fields and functions]] are available on date objects.
+- Many other [[functions|fields and functions]] are available on date objects.
 
 ### Objects and lists
 
@@ -351,9 +351,9 @@ Dates represent a specific date, or a date and time depending on the function us
 
 ### Files and links
 
-[[Link notes|Wikilinks]] in [[Properties|frontmatter properties]] are automatically recognized as Link objects. Links will render as a clickable link in the [[Views|view]].
+[[Link notes|Wikilinks]] in [[PROPERTIES|frontmatter properties]] are automatically recognized as Link objects. Links will render as a clickable link in the [[views|view]].
 
-- To construct a link, use the global `link` [[Functions|function]], for example `link("filename")` or `link("https://obsidian.md")`.
+- To construct a link, use the global `link` [[functions|function]], for example `link("filename")` or `link("https://obsidian.md")`.
 - You can create a link from any string, for example, `link(file.ctime.date().toString())`.
 - To set the display text, pass in an optional string or icon as a second parameter, for example `link("filename", "display")` or `link("filename", icon("plus"))`.
 

--- a/skills/obsidian-bases/references/views.md
+++ b/skills/obsidian-bases/references/views.md
@@ -41,7 +41,7 @@ Views can be displayed with different layouts including as  ![[lucide-table.svg#
 
 | Layout                | Description                                                                                   | App&nbsp;version |
 | --------------------- | --------------------------------------------------------------------------------------------- | ---------------- |
-| [[Table view\|Table]] | Display files as rows in a table. Columns are populated from [[properties]] in your notes.    | 1.9              |
+| [[Table view\|Table]] | Display files as rows in a table. Columns are populated from [[PROPERTIES]] in your notes.    | 1.9              |
 | [[Cards view\|Cards]] | Display files as a grid of cards. Lets you create gallery-like views with images.             | 1.9              |
 | [[List view\|List]]   | Display files as a [[Basic formatting syntax#Lists\|list]] with bulleted or numbered markers. | 1.10             |
 | [[Map view\|Map]]     | Display files as pins on an interactive map. Requires the Maps plugin.                        | 1.10             |
@@ -62,9 +62,9 @@ Filters can be applied to all views in a base, or just a single view by choosing
 
 Filters have three components:
 
-1. **Property** — lets you choose a [[Properties|property]] in your vault, including [[Bases syntax#File properties|file properties]].
+1. **Property** — lets you choose a [[PROPERTIES|property]] in your vault, including [[Bases syntax#File properties|file properties]].
 2. **Operator** — lets you choose how to compare the conditions. The list of available operators depends on the property type (text, date, number, etc) 
-3. **Value** — lets you choose the value you are comparing to. Values can include math and [[Functions|functions]].
+3. **Value** — lets you choose the value you are comparing to. Values can include math and [[functions|functions]].
 
 #### Conjunctions
 
@@ -78,7 +78,7 @@ Filter groups allow you to create more complex logic by creating combinations on
 
 #### Advanced filter editor
 
-Click the code button ![[lucide-code-xml.svg#icon]] to use the **advanced filter** editor. This displays the raw [[Bases syntax|syntax]] for the filter, and can be used with more complex [[Functions|functions]] that cannot be displayed using the point-and-click interface.
+Click the code button ![[lucide-code-xml.svg#icon]] to use the **advanced filter** editor. This displays the raw [[Bases syntax|syntax]] for the filter, and can be used with more complex [[functions|functions]] that cannot be displayed using the point-and-click interface.
 
 ## Sort and group results
 

--- a/skills/obsidian-cli/.deploy_scope
+++ b/skills/obsidian-cli/.deploy_scope
@@ -1,1 +1,1 @@
-xia
+global

--- a/skills/obsidian-clipper-template-creator/.deploy_scope
+++ b/skills/obsidian-clipper-template-creator/.deploy_scope
@@ -1,1 +1,1 @@
-xia
+global

--- a/skills/obsidian-markdown/.deploy_scope
+++ b/skills/obsidian-markdown/.deploy_scope
@@ -1,1 +1,1 @@
-xia
+global

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -7,7 +7,13 @@ description: Create and edit Obsidian Flavored Markdown with wikilinks, embeds, 
 
 ## Overview
 
-Create and edit valid Obsidian Flavored Markdown (OFM) that also obeys the user's two personal formatting rules. OFM extends CommonMark and GFM with wikilinks, embeds, callouts, properties, comments, and other syntax; this skill covers those extensions and bakes the user's heading-depth and bullet-depth preferences into every note it produces. Standard Markdown (bold, italic, code blocks, tables) is assumed knowledge.
+Create and edit valid Obsidian Flavored Markdown (OFM) that also obeys the user's two personal formatting rules.
+
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
+OFM extends CommonMark and GFM with wikilinks, embeds, callouts, properties, comments, and other syntax; this skill covers those extensions and bakes the user's heading-depth and bullet-depth preferences into every note it produces. Standard Markdown (bold, italic, code blocks, tables) is assumed knowledge.
 
 ## When to Use
 
@@ -21,11 +27,11 @@ Create and edit valid Obsidian Flavored Markdown (OFM) that also obeys the user'
 
 ## Workflow
 
-1. **Add frontmatter** with properties (title, tags, aliases) at the top of the file. See [PROPERTIES.md](references/PROPERTIES.md) for all property types.
+1. **Add frontmatter** with properties (title, tags, aliases) at the top of the file. See [PROPERTIES.md](PROPERTIES.md) for all property types.
 2. **Write content** using standard Markdown for structure, plus the OFM syntax below.
 3. **Link related notes** using wikilinks (`[[Note]]`) for internal vault connections, and standard Markdown links for external URLs.
-4. **Embed content** from other notes, images, or PDFs using `![[embed]]`. See [EMBEDS.md](references/EMBEDS.md).
-5. **Add callouts** for highlighted information using `> [!type]`. See [CALLOUTS.md](references/CALLOUTS.md).
+4. **Embed content** from other notes, images, or PDFs using `![[embed]]`. See [EMBEDS.md](EMBEDS.md).
+5. **Add callouts** for highlighted information using `> [!type]`. See [CALLOUTS.md](CALLOUTS.md).
 6. **Check formatting against the Formatting Rules below** -- no H1, no H5+, no bullet past depth 3. Fix before moving on.
 7. **Verify** the note renders correctly in Obsidian's reading view.
 
@@ -110,7 +116,7 @@ Prefix any wikilink with `!` to embed its content inline:
 ![[document.pdf#page=3]]               Embed PDF page
 ```
 
-See [EMBEDS.md](references/EMBEDS.md) for audio, video, search embeds, and external images.
+See [EMBEDS.md](EMBEDS.md) for audio, video, search embeds, and external images.
 
 ## Callouts
 
@@ -127,7 +133,7 @@ See [EMBEDS.md](references/EMBEDS.md) for audio, video, search embeds, and exter
 
 Common types: `note`, `tip`, `warning`, `info`, `example`, `quote`, `bug`, `danger`, `success`, `failure`, `question`, `abstract`, `todo`.
 
-See [CALLOUTS.md](references/CALLOUTS.md) for the full list with aliases, nesting, and custom CSS callouts.
+See [CALLOUTS.md](CALLOUTS.md) for the full list with aliases, nesting, and custom CSS callouts.
 
 ## Properties (Frontmatter)
 
@@ -145,7 +151,7 @@ cssclasses:
 ---
 ```
 
-Default properties: `tags` (searchable labels), `aliases` (alternative note names for link suggestions), `cssclasses` (CSS classes for styling). See [PROPERTIES.md](references/PROPERTIES.md) for all property types, tag syntax rules, and advanced usage.
+Default properties: `tags` (searchable labels), `aliases` (alternative note names for link suggestions), `cssclasses` (CSS classes for styling). See [PROPERTIES.md](PROPERTIES.md) for all property types, tag syntax rules, and advanced usage.
 
 ## Tags
 
@@ -278,7 +284,7 @@ Reviewed in [[Meeting Notes 2024-01-10#Decisions]].
 - [ ] `grep -nE '^#{5,} ' <note>` returns zero matches (no H5+).
 - [ ] `grep -nE '^ {6,}- |^\t{3,}- ' <note>` returns zero matches for 2-space indentation (or `^ {12,}-` for 4-space).
 - [ ] Every wikilink resolves to an existing note or is explicitly intended as a placeholder.
-- [ ] Callouts use a valid type from [CALLOUTS.md](references/CALLOUTS.md).
+- [ ] Callouts use a valid type from [CALLOUTS.md](CALLOUTS.md).
 - [ ] The note renders in Obsidian reading view without broken embeds or unrendered syntax.
 
 ## References

--- a/skills/obsidian-mermaid/.deploy_scope
+++ b/skills/obsidian-mermaid/.deploy_scope
@@ -1,1 +1,1 @@
-xia
+global

--- a/skills/obsidian-mermaid/SKILL.md
+++ b/skills/obsidian-mermaid/SKILL.md
@@ -7,7 +7,11 @@ description: Use when you need Mermaid diagrams that render correctly in Obsidia
 
 ## Overview
 
-Obsidian bundles Mermaid 11.4.1 (behind the current release). Diagrams from mermaid.live or AI tools often break because of `\n` in labels, unquoted special characters, subgraph direction, or post-11.4.1 diagram types. This skill encodes what actually works. See also `obsidian-mermaid.md` in this folder for the full reference.
+Obsidian bundles Mermaid 11.4.1 (behind the current release). Diagrams from mermaid.live or AI tools often break because of `\n` in labels, unquoted special characters, subgraph direction, or post-11.4.1 diagram types. This skill encodes what actually works.
+
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
 
 ## Key Constraints
 

--- a/skills/obsidian-sync/.deploy_scope
+++ b/skills/obsidian-sync/.deploy_scope
@@ -1,1 +1,1 @@
-xia
+global

--- a/skills/openclaw/SKILL.md
+++ b/skills/openclaw/SKILL.md
@@ -5,13 +5,10 @@ description: Manage OpenClaw agent lifecycle on m1-pro — add/remove/modify age
 
 # openclaw
 
-> [!warning] Deprecated (2026-04-21)
-> OpenClaw is being replaced by [[Hermes Agent|Hermes]] on m1-pro. BNC/GDR cron and skill pipeline are moving to Hermes per `.omc/plans/2026-04-21-hermes-skill-pipeline-retarget.md`. This skill is preserved for 30 days as a rollback fallback; new work should target Hermes via `skill-deploy`'s Hermes leg.
-
 ## Overview
-Operate the OpenClaw multi-agent gateway running on m1-pro. OpenClaw is the "지휘자" (conductor) — it receives messages from Discord/Telegram/Slack, routes them to the appropriate AI agent, and returns responses. This skill captures personal operational context that generic docs do not cover. For standard CLI reference and setup instructions, query NotebookLM MCP with the OpenClaw documentation.
+Operate the OpenClaw multi-agent gateway running on m1-pro. OpenClaw runs in parallel with the Hermes Docker runtime; both are live on m1-pro and have distinct workspaces. Use this skill when the task targets the OpenClaw gateway specifically; use the Hermes skill family when the task targets the Hermes runtime. OpenClaw is the "지휘자" (conductor) — it receives messages from Discord/Telegram/Slack, routes them to the appropriate AI agent, and returns responses. This skill captures personal operational context that generic docs do not cover. For standard CLI reference and setup instructions, query NotebookLM MCP with the OpenClaw documentation.
 
-Vault reference: `Ataraxia/50. AI/04 Skills/openclaw/` is the live vault source for this skill package and its supporting references.
+Vault reference: `Ataraxia/50. AI/04 Skills/Obsidian/openclaw/` is the live vault source for this skill package and its supporting references.
 
 ## When to Use
 - Adding, removing, or modifying agents (model change, identity update, skill assignment)
@@ -65,11 +62,11 @@ openclaw agents add \
   --model <model-id>
 ```
 After adding, create bootstrap files in the workspace root:
-- `SOUL.md` — 말투, 톤, 성격 ("where your agent's voice lives"). 매 턴 주입됨.
-- `IDENTITY.md` — 이름, 이모지, 아바타 (메타데이터)
-- `AGENTS.md` — 운영 규칙
-- `TOOLS.md` — 로컬 설정 (SSH hosts, API keys)
-- `USER.md` — 사용자 선호/맥락
+- `SOUL.md` — speech style, tone, and personality ("where your agent's voice lives"). Injected every turn.
+- `IDENTITY.md` — name, emoji, avatar (agent metadata)
+- `AGENTS.md` — operational rules
+- `TOOLS.md` — local settings (SSH hosts, API keys)
+- `USER.md` — user preferences and context
 
 **Remove an agent:**
 ```bash
@@ -136,47 +133,47 @@ ls ~/.openclaw/skills/
 
 To add a skill, copy the SKILL.md (and supporting files) into a named subdirectory. To remove, delete the directory. After changes, the agent picks up skills on next session start — no gateway restart needed.
 
-### 7. Agent persona/speech style 변경
+### 7. Agent persona and speech style changes
 
-Bootstrap 파일(SOUL.md 등)은 **매 턴** 주입된다 (`contextInjection: "always"` 기본값). 단, 기존 Discord 세션은 이전 bootstrap을 캐시하므로 transcript 삭제 후 새 세션을 시작해야 변경이 반영된다.
+Bootstrap files (SOUL.md, etc.) are injected **every turn** (`contextInjection: "always"` by default). However, existing Discord sessions cache the previous bootstrap, so you must delete the transcript and start a new session for changes to take effect.
 
-**중요**: Bootstrap 파일은 **workspace 디렉토리**에서 로딩된다 (agentDir 아님). `openclaw.json`의 `agents.list[].workspace` 필드가 로딩 경로를 결정한다.
+**Important**: Bootstrap files are loaded from the **workspace directory** (not agentDir). The `agents.list[].workspace` field in `openclaw.json` determines the loading path.
 
-**말투/성격 변경:**
+**Update speech style or personality:**
 ```bash
-# SOUL.md 수정 (workspace root에 위치)
+# Edit SOUL.md (located at workspace root)
 vi <workspace-path>/SOUL.md
 ```
 
-**메타데이터(이름/이모지/아바타) 변경:**
+**Update metadata (name / emoji / avatar):**
 ```bash
 vi <workspace-path>/IDENTITY.md
 openclaw agents set-identity --agent <name> --from-identity
 ```
 
-**변경 반영 — Gateway 재시작 + 세션 리셋:**
-Gateway가 bootstrap 파일을 메모리에 캐시하므로, 파일 수정 후 반드시 Gateway를 재시작해야 한다. 세션 리셋만으로는 부족.
+**Apply changes — Gateway restart + session reset:**
+The gateway caches bootstrap files in memory, so a file edit alone is not enough. You must restart the gateway after any bootstrap file change. A session reset alone is insufficient.
 ```bash
-# 1. Gateway 재시작 (필수)
+# 1. Restart the gateway (required)
 launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 sleep 5
-curl -s http://127.0.0.1:18789/health   # 정상 확인
+curl -s http://127.0.0.1:18789/health   # confirm healthy
 
-# 2. 세션 ID 확인
+# 2. Identify the current session ID
 openclaw sessions --agent <name> --json
 
-# 3. transcript 백업 후 삭제
+# 3. Back up and delete the transcript
 cp ~/.openclaw/agents/<name>/sessions/<session-id>.jsonl /tmp/<backup-name>.jsonl
 rm ~/.openclaw/agents/<name>/sessions/<session-id>.jsonl
 
-# 4. sessions.json 정리
+# 4. Clean up sessions.json
 openclaw sessions cleanup --agent <name> --fix-missing --enforce
 ```
-다음 Discord 메시지에서 새 세션이 시작되며 새 SOUL.md가 주입된다.
+The next Discord message will start a fresh session and inject the new SOUL.md.
 
-**CLI에서 테스트:**
+**Test from CLI:**
 ```bash
-# 새 session-id로 강제 새 세션
+# Force a new session with a fresh session-id
 openclaw agent --agent <name> --session-id test-$(date +%s) --message '테스트 메시지'
 ```
 
@@ -247,7 +244,7 @@ rm -rf ~/.openclaw/skills/<project-skill>/
 ```
 
 6. **Update vault references:**
-- Check `Ataraxia/50. AI/04 Skills/openclaw/references/operations.md` for agent references and operational notes
+- Check `Ataraxia/50. AI/04 Skills/Obsidian/openclaw/references/operations.md` for agent references and operational notes
 - Update agent composition tables in terminology notes
 - Remove or archive related workspace notes
 
@@ -260,20 +257,20 @@ curl -s http://127.0.0.1:18789/health   # Gateway still healthy
 
 ## Reference
 
-For architecture diagrams, agent composition, session protocol, heartbeat vs cron, and troubleshooting (삽질 기록), see [references/operations.md](references/operations.md).
+For architecture diagrams, agent composition, session protocol, heartbeat vs cron, and troubleshooting (삽질 기록), see [references/operations.md](50.%20AI/04%20Skills/Obsidian/openclaw/references/operations.md).
 
 ## Common Rationalizations
 | Rationalization | Reality |
 |---|---|
 | "The agent will pick up the new channel binding immediately." | The binding is registered but the channel must also be in the guild allowlist. Without it, responses are silently dropped. |
 | "I can skip IDENTITY.md for a quick test." | The agent will respond with the wrong identity, confusing users and polluting conversation history. Always create it. |
-| "SOUL.md를 수정했으니 바로 반영될 거야." | Gateway가 bootstrap 파일을 메모리에 캐시한다. 파일 수정 후 반드시 Gateway 재시작(`launchctl kickstart`) + 세션 리셋이 필요. |
-| "세션 리셋만 하면 SOUL.md 변경이 반영될 거야." | 세션 리셋(transcript 삭제)은 새 세션을 시작하지만, Gateway가 캐시한 옛날 bootstrap을 그대로 주입한다. Gateway 재시작이 선행되어야 한다. |
-| "agentDir에 IDENTITY.md를 넣으면 되지." | Bootstrap 파일은 workspace 디렉토리에서 로딩된다. agentDir는 세션/인증 등 런타임 상태 전용. workspace 경로는 `openclaw.json`의 `agents.list[].workspace`로 확인. |
-| "말투는 IDENTITY.md에 넣으면 되지." | IDENTITY.md는 이름/이모지/아바타 메타데이터 전용. 말투/톤/성격은 SOUL.md에 넣어야 한다. |
-| "BOOTSTRAP.md에 운영 규칙을 넣으면 되지." | BOOTSTRAP.md는 일회성(삭제됨). 매 세션 로딩되는 AGENTS.md에 넣어야 한다. |
-| "AGENTS.md를 수정하면 바로 반영되지." | 기존 세션은 이전 AGENTS.md를 캐시한다. Gateway 재시작 + 세션 삭제로 새 세션을 강제해야 반영. |
-| "maestro가 알아서 올바른 OMX 플래그를 쓰겠지." | AGENTS.md에 `--madmax --high` 강제 규칙이 없으면 maestro가 플래그 없이 세션을 시작한다. 명시적 규칙 필수. |
+| "Editing SOUL.md takes effect immediately." | The gateway caches bootstrap files in memory. After editing, a gateway restart (`launchctl kickstart`) plus a session reset are both required. |
+| "A session reset is enough to pick up SOUL.md changes." | Resetting the session (deleting the transcript) starts a new session, but the gateway still injects the old cached bootstrap. The gateway must be restarted first. |
+| "I can put IDENTITY.md in agentDir." | Bootstrap files are loaded from the workspace directory, not agentDir. agentDir is for runtime state (sessions, auth). Confirm the workspace path via `agents.list[].workspace` in `openclaw.json`. |
+| "Speech style goes in IDENTITY.md." | IDENTITY.md is for name/emoji/avatar metadata only. Speech style, tone, and personality belong in SOUL.md. |
+| "Operational rules can go in BOOTSTRAP.md." | BOOTSTRAP.md is one-shot (deleted after first run). Persistent rules must go in AGENTS.md, which is loaded every session. |
+| "Editing AGENTS.md takes effect immediately." | Existing sessions cache the previous AGENTS.md. Force a fresh session via gateway restart + session deletion. |
+| "Maestro will use the correct OMX flags on its own." | Without an explicit `--madmax --high` rule in AGENTS.md, maestro starts sessions without those flags. Explicit rules are required. |
 | "Removing the agent from the CLI is enough." | Cron entries, channel bindings, filesystem artifacts, and vault references all need separate cleanup. |
 | "I'll manage the gateway process manually." | Gateway is launchd-managed. Use launchctl, not kill/nohup. |
 
@@ -284,8 +281,8 @@ For architecture diagrams, agent composition, session protocol, heartbeat vs cro
 - Cron entries left orphaned after agent removal
 - Gateway managed via nohup instead of launchctl
 - PATH not exported in cron scripts that use obsidian CLI
-- Bootstrap 파일 수정 후 Gateway 재시작 없이 Discord/메신저에서 테스트
-- CLI에서만 테스트하고 Discord 검증을 건너뜀 (CLI는 direct session, Discord는 group session으로 동작이 다를 수 있음)
+- Bootstrap files modified but gateway not restarted before testing via Discord or messenger
+- Testing only via CLI without validating in Discord (CLI uses a direct session; Discord uses a group session and may behave differently)
 
 ## Verification
 After completing the workflow, confirm:
@@ -295,5 +292,5 @@ After completing the workflow, confirm:
 - [ ] If agent added: IDENTITY.md, SOUL.md, USER.md exist in **workspace** directory (not agentDir)
 - [ ] If channel bound: channel appears in guild allowlist
 - [ ] If agent removed: no orphaned cron entries, channel bindings cleaned, filesystem artifacts removed
-- [ ] If bootstrap files modified: Gateway 재시작 완료 (`launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway`)
+- [ ] If bootstrap files modified: gateway restarted (`launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway`)
 - [ ] Gateway health check passes: `curl -s http://127.0.0.1:18789/health`

--- a/skills/reflect-dankoe/SKILL.md
+++ b/skills/reflect-dankoe/SKILL.md
@@ -8,6 +8,10 @@ description: Use when you need to run a structured daily reflection protocol ins
 ## Overview
 Use this skill to run a structured reflection routine based on a question protocol. The public-safe version preserves the guided reflection flow while removing private daily-note assumptions and personal naming conventions.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 - Use when the user explicitly wants to do a guided reflection run
 - Use when a one-question-at-a-time reflection protocol is needed

--- a/skills/rize/SKILL.md
+++ b/skills/rize/SKILL.md
@@ -15,6 +15,10 @@ FORMAT=markdown /path/to/fetch_rize_data.sh "<natural language request>"
 
 `FORMAT=markdown` returns ready-to-use Obsidian markdown. Without `FORMAT`, returns raw JSON for programmatic use.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 - Use when the user asks about Rize data, focus time, categories, or projects
 - Use when a deterministic fetch-and-format workflow should produce structured output

--- a/skills/skill-deploy/SKILL.md
+++ b/skills/skill-deploy/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: skill-deploy
-description: Push publishable skills from the vault SSOT to GoBeromsu/agent-skills on GitHub, then sync every downstream target — local Claude Code, m1-pro Claude Code, and m1-pro Hermes Docker runtime at `~/.hermes/skills/` (global) or `~/.hermes/agents/xia/workspace/skills/` (xia-scoped) over tailscale. Use when the user says "/skill-deploy", "스킬 배포", "publish skills", or wants to update any deployed skill surface from the vault SSOT after skill edits.
+description: Push publishable skills from the vault SSOT to GoBeromsu/obsidian-agent-skills on GitHub, then fan out to every runtime declared in each skill's `agent_skill_scope` — Codex CLI (`~/.codex/skills/`), local + m1-pro Claude Code (`~/.claude/skills/Obsidian/`), m1-pro OpenClaw workspace, and m1-pro Hermes Docker runtime (`~/.hermes/skills/`). Use when the user says "/skill-deploy", "스킬 배포", "publish skills", or wants to update any deployed skill surface from the vault SSOT after skill edits.
 ---
 
 # skill-deploy
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## Overview
 
-Push publishable skills from the vault SSOT to GitHub, then fan out to every downstream surface. The vault copy under `50. AI/04 Skills/` is the source of truth; GitHub, local Claude Code, m1-pro Claude Code, and m1-pro Hermes (`~/.hermes/skills/`) via Docker are mirrors. All must be updated in the same run, or agents reading from a stale surface will silently drift. See also `[[504.02 Hermes]]`, `[[Hermes Agent]]`, `[[2026-04-21-hermes-skill-pipeline-retarget]]`.
+Push publishable skills from the vault SSOT to GitHub, then fan out to every downstream surface declared in each skill's `agent_skill_scope` list. The vault copy under `50. AI/04 Skills/Obsidian/` is the source of truth; GitHub, Codex CLI, local + m1-pro Claude Code, m1-pro OpenClaw, and m1-pro Hermes Docker are mirrors. All surfaces listed on a skill must be updated in the same run, or agents reading from a stale surface will silently drift. See also `[[504.02 Hermes]]`, `[[Hermes Agent]]`, `[[11. Skill Guideline]]`.
 
 ## When to Use
 
@@ -18,52 +22,61 @@ Push publishable skills from the vault SSOT to GitHub, then fan out to every dow
 
 ## Deployment Targets
 
-One source, five sinks. If any target fails, the deploy is partial and must be retried.
+One source, five sinks. Each skill declares which sinks receive it through its `agent_skill_scope` list (see [[11. Skill Guideline]] § agent_skill_scope Target Map). If any declared target fails, the deploy is partial and must be retried.
 
-| # | Target | Transport | Destination | Sync Command |
-|---|--------|-----------|-------------|--------------|
-| 1 | GitHub SSOT mirror | Branch + PR + squash-merge via `gh` | `GoBeromsu/agent-skills` (main) | Step 5: `gh pr create` → `gh pr merge --squash --admin` |
-| 2 | Local Claude Code plugin | `claude plugins update` | `~/.claude/plugins/cache/beomsu-koh/agent-skills/<ver>/` | `claude plugins update agent-skills@beomsu-koh` |
-| 3 | m1-pro Claude Code plugin | ssh over tailscale | same path on m1-pro | `ssh m1-pro claude plugins update agent-skills@beomsu-koh` |
-| 4 | m1-pro Hermes global skills | docker cp via ssh (tailscale) | `$HC:/root/.hermes/skills/<skill>/` | per-skill rsync stage → `docker cp` |
-| 5 | m1-pro Hermes xia workspace | docker cp via ssh (tailscale) | `$HC:/root/.hermes/agents/xia/workspace/skills/<skill>/` | per-skill rsync stage → `docker cp` |
+| # | `agent_skill_scope` value | Target | Transport | Destination | Sync Command |
+|---|---|--------|-----------|-------------|--------------|
+| 1 | (always) | GitHub SSOT mirror | Branch + PR + squash-merge via `gh` | `GoBeromsu/obsidian-agent-skills` (main), under `skills/Obsidian/` | Step 5: `gh pr create` → `gh pr merge --squash --admin` |
+| 2 | `claude` | Local Claude Code plugin | `claude plugins update` | `~/.claude/skills/Obsidian/<skill>/` | `claude plugins update obsidian-agent-skills@beomsu-koh` |
+| 3 | `claude` | m1-pro Claude Code plugin | ssh over tailscale | same path on m1-pro | `ssh m1-pro claude plugins update obsidian-agent-skills@beomsu-koh` |
+| 4 | `codex` | Codex CLI | rsync | `~/.codex/skills/<skill>/` | `rsync -av --delete "$VAULT/<skill>/" ~/.codex/skills/<skill>/` |
+| 5 | `openclaw` | m1-pro OpenClaw workspace | rsync over ssh (tailscale) | OpenClaw skills path on m1-pro (managed by the `openclaw` skill) | per-skill rsync |
+| 6 | `hermes` | m1-pro Hermes global skills | docker cp via ssh (tailscale) | `$HC:/root/.hermes/skills/<skill>/` | per-skill rsync stage → `docker cp` |
 
-All five legs are independent. Skills without `publish: true` are vault-only and filtered in Step 1. Hermes has private skills from `hermes claw migrate`; `docker cp` per-skill is the only safe ingress. Full rationale: `references/hermes-target.md`.
+Target #1 (GitHub) is the SSOT mirror and always runs; every other target is conditional on the presence of its scope value in the skill's `agent_skill_scope`. Skills without `publish: true` are vault-only and filtered in Step 1. Hermes has private skills from `hermes claw migrate`; `docker cp` per-skill is the only safe ingress. Full rationale: `references/hermes-target.md`.
 
 ## Process
 
 ### Step 1 — Scan SSOT
 
-Vault root: `/Users/beomsu/Documents/01. Obsidian/Ataraxia/50. AI/04 Skills/`
+Vault root: `/Users/beomsu/Documents/01. Obsidian/Ataraxia/50. AI/04 Skills/Obsidian/`
 
-For each subdirectory: verify `SKILL.md` exists; check `{skill-name}.md` for `publish: true`; read `deploy_scope` — `global` → target #4, `xia` → target #5, missing → default `global` with WARN.
+For each subdirectory: verify `SKILL.md` exists; check `{skill-name}.md` for `publish: true`; read `agent_skill_scope` (list). Missing `agent_skill_scope` → default to `[claude]` and log `WARN: missing agent_skill_scope, defaulting to [claude]`. Unknown values (anything outside `codex`, `claude`, `openclaw`, `hermes`) → abort with error.
 
 ### Steps 2–5 — Repo prep, copy, version bump, PR
 
-Full bash blocks in `references/hermes-target.md §GitHub deploy runbook`. Key invariants: always `git pull --rebase` before branching; always bump `.claude-plugin/plugin.json`; use `gh pr merge --squash --admin --delete-branch`; never push directly to `main`. After copying each skill write: `echo "$scope" > "$REPO/skills/$skill/.deploy_scope"` — Step 6b reads this file.
+Full bash blocks in `references/hermes-target.md § GitHub deploy runbook`. Key invariants: always `git pull --rebase` before branching; copy each skill into `$REPO/skills/Obsidian/<skill>/`; always bump `.claude-plugin/plugin.json`; use `gh pr merge --squash --admin --delete-branch`; never push directly to `main`. After copying each skill write the scope list: `printf '%s\n' "${scope[@]}" > "$REPO/skills/Obsidian/$skill/.agent_skill_scope"` — Step 6 reads this file.
 
 ### Step 6 — Sync Deployed Mirrors
 
-**6a. Claude Code plugins (targets #2, #3):**
+**6a. Claude Code plugins (target #2 + #3, gated on `claude` in scope):**
 
 ```bash
-claude plugins update agent-skills@beomsu-koh
-ssh m1-pro claude plugins update agent-skills@beomsu-koh
+claude plugins update obsidian-agent-skills@beomsu-koh
+ssh m1-pro claude plugins update obsidian-agent-skills@beomsu-koh
 ```
 
-**6b. m1-pro Hermes runtime (targets #4 and #5):**
+**6b. Codex CLI (target #4, gated on `codex` in scope):**
+
+```bash
+mkdir -p ~/.codex/skills
+for skill in $(ls "$REPO/skills/Obsidian"); do
+  grep -qx codex "$REPO/skills/Obsidian/$skill/.agent_skill_scope" || continue
+  rsync -av --delete "$REPO/skills/Obsidian/$skill/" "$HOME/.codex/skills/$skill/"
+done
+```
+
+**6c. m1-pro OpenClaw workspace (target #5, gated on `openclaw` in scope):** follow the `openclaw` skill for the current workspace path; deploy per-skill rsync after confirming the OpenClaw gateway is healthy.
+
+**6d. m1-pro Hermes runtime (target #6, gated on `hermes` in scope):**
 
 ```bash
 HC=$(ssh m1-pro 'docker ps --filter name=hermes --format "{{.Names}}" | head -1')
 ssh m1-pro 'mkdir -p ~/.hermes-stage'
-for skill in $(ls "$REPO/skills"); do
-  scope=$(cat "$REPO/skills/$skill/.deploy_scope" 2>/dev/null || echo global)
-  rsync -av --delete "$REPO/skills/$skill/" "m1-pro:.hermes-stage/$skill/"
-  if [ "$scope" = "xia" ]; then
-    ssh m1-pro "docker cp ~/.hermes-stage/$skill $HC:/root/.hermes/agents/xia/workspace/skills/"
-  else
-    ssh m1-pro "docker cp ~/.hermes-stage/$skill $HC:/root/.hermes/skills/"
-  fi
+for skill in $(ls "$REPO/skills/Obsidian"); do
+  grep -qx hermes "$REPO/skills/Obsidian/$skill/.agent_skill_scope" || continue
+  rsync -av --delete "$REPO/skills/Obsidian/$skill/" "m1-pro:.hermes-stage/$skill/"
+  ssh m1-pro "docker cp ~/.hermes-stage/$skill $HC:/root/.hermes/skills/"
 done
 ```
 
@@ -71,30 +84,33 @@ Hermes cron CLI fallback and container lifecycle notes: `references/hermes-targe
 
 ### Step 7 — Report
 
-Print deployed/skipped counts for all five targets. Verify remote: `gh api repos/GoBeromsu/agent-skills/contents/skills --jq '.[].name'`.
+Print deployed/skipped counts for all six targets. Verify remote: `gh api repos/GoBeromsu/obsidian-agent-skills/contents/skills/Obsidian --jq '.[].name'`.
 
 ## Common Rationalizations
 
 | Rationalization | Reality |
 |---|---|
-| "The push succeeded so every machine is up to date." | Push updates GitHub only. All five targets must run their own sync. |
+| "The push succeeded so every machine is up to date." | Push updates GitHub only. Every target declared in a skill's `agent_skill_scope` must run its own sync. |
 | "I'll edit the deployed plugin cache directly." | Cache is overwritten on next update. Edit the SSOT only. |
 | "Plugins update covers Hermes too." | Hermes reads only `~/.hermes/skills/`. Without `docker cp`, it keeps yesterday's skill. |
 | "I'll rsync directly into the running container." | Unreliable across Docker overlayfs. Stage on host first, then `docker cp`. |
+| "A skill with missing `agent_skill_scope` should fan out everywhere." | Missing field defaults to `[claude]` only, with a WARN. Silent fan-out risks publishing to a surface the author did not intend. |
 
 ## Red Flags
 
 - `git push origin main` directly (blocked by agent policy)
 - Pushing without bumping `.claude-plugin/plugin.json` version
 - Running `rsync -av --delete` directly into a live container overlayfs without staging on host first
-- Adding a new deployment target without updating the Deployment Targets table
+- Adding a new deployment target without updating the Deployment Targets table and `agent_skill_scope` target map in `[[11. Skill Guideline]]`
 - Skipping the Hermes `docker cp` leg because "the plugin update already ran"
+- Treating the absence of `agent_skill_scope` as "deploy to everything"
 
 ## Verification
 
-- [ ] Each deployed skill has `publish: true` in its `{skill-name}.md`; `.claude-plugin/plugin.json` bumped
+- [ ] Each deployed skill has `publish: true` in its `{skill-name}.md` and a valid `agent_skill_scope` list; `.claude-plugin/plugin.json` bumped
 - [ ] PR squash-merged `--admin --delete-branch`; local `main` rebased
-- [ ] `claude plugins update agent-skills@beomsu-koh` exits 0 on local and m1-pro
-- [ ] Hermes global: `ssh m1-pro "docker exec $HC ls /root/.hermes/skills/<skill>/SKILL.md"` returns path
-- [ ] Hermes xia: `ssh m1-pro "docker exec $HC ls /root/.hermes/agents/xia/workspace/skills/<skill>/SKILL.md"` returns path
-- [ ] Hermes-private skills still present; deployment report covers all five targets
+- [ ] `claude plugins update obsidian-agent-skills@beomsu-koh` exits 0 on local and m1-pro for every skill with `claude` in scope
+- [ ] Codex surface: `ls ~/.codex/skills/<skill>/SKILL.md` returns path for every skill with `codex` in scope
+- [ ] OpenClaw surface: skill present in the OpenClaw workspace for every skill with `openclaw` in scope
+- [ ] Hermes global: `ssh m1-pro "docker exec $HC ls /root/.hermes/skills/<skill>/SKILL.md"` returns path for every skill with `hermes` in scope
+- [ ] Hermes-private skills still present; deployment report covers all six targets

--- a/skills/skill-deploy/references/hermes-target.md
+++ b/skills/skill-deploy/references/hermes-target.md
@@ -13,29 +13,31 @@ Historical note: before 2026-04-21, target #4 deployed to `m1-pro:~/.openclaw/sk
 ## GitHub deploy runbook (Steps 2–5)
 
 ```bash
-REPO="${AGENT_SKILLS_REPO_PATH:-$HOME/dev/agent-skills}"
-VAULT="/Users/beomsu/Documents/01. Obsidian/Ataraxia/50. AI/04 Skills"
+REPO="${OBSIDIAN_AGENT_SKILLS_REPO_PATH:-$HOME/dev/obsidian-agent-skills}"
+VAULT="/Users/beomsu/Documents/01. Obsidian/Ataraxia/50. AI/04 Skills/Obsidian"
 
 # Step 2 — Prepare repo
 if [ ! -d "$REPO/.git" ]; then
-  gh repo view GoBeromsu/agent-skills &>/dev/null || \
-    gh repo create GoBeromsu/agent-skills --public \
-      --description "Personal Claude Code skill collection"
-  gh repo clone GoBeromsu/agent-skills "$REPO"
+  gh repo view GoBeromsu/obsidian-agent-skills &>/dev/null || \
+    gh repo create GoBeromsu/obsidian-agent-skills --public \
+      --description "Personal Claude Code + Codex + Hermes skill collection"
+  gh repo clone GoBeromsu/obsidian-agent-skills "$REPO"
 fi
 git -C "$REPO" pull --rebase
 
 # Step 3 — Copy publishable skills
 for skill in <publishable-skill-list>; do
-  DEST="$REPO/skills/$skill"
+  DEST="$REPO/skills/Obsidian/$skill"
   mkdir -p "$DEST"
   cp "$VAULT/$skill/SKILL.md" "$DEST/"
   for dir in scripts references assets; do
     [ -d "$VAULT/$skill/$dir" ] && cp -r "$VAULT/$skill/$dir/" "$DEST/$dir/"
   done
-  # Write scope marker for Step 6b
-  scope=$(grep '^deploy_scope:' "$VAULT/$skill/$skill.md" 2>/dev/null | awk '{print $2}' || echo global)
-  echo "$scope" > "$DEST/.deploy_scope"
+  # Write agent_skill_scope marker for Step 6 gating
+  STUB="$VAULT/$skill/$skill.md"
+  awk '/^agent_skill_scope:/{flag=1;next} /^[a-zA-Z_]+:/{flag=0} flag && /^  - /{print $2}' "$STUB" > "$DEST/.agent_skill_scope"
+  # Default to [claude] if the stub is missing the field
+  [ -s "$DEST/.agent_skill_scope" ] || echo claude > "$DEST/.agent_skill_scope"
 done
 
 # Step 4 — Version bump
@@ -58,7 +60,7 @@ git -C "$REPO" diff --cached --quiet && {
 }
 git -C "$REPO" commit -m "deploy: sync skills from vault ($(date +%Y-%m-%d))"
 git -C "$REPO" push -u origin "$BRANCH"
-PR_URL=$(gh pr create --repo GoBeromsu/agent-skills \
+PR_URL=$(gh pr create --repo GoBeromsu/obsidian-agent-skills \
   --title "deploy: sync skills from vault ($(date +%Y-%m-%d))" \
   --body "Automated deploy from skill-deploy. See commits for details." \
   --base main --head "$BRANCH")
@@ -116,12 +118,6 @@ ssh m1-pro "docker exec $HC gws auth status"
 
 If auth is missing, either run `docker exec $HC gws auth login` or bind-mount the host credentials: add `-v $HOME/.config/gws:/root/.config/gws` to the container run command.
 
-## OpenClaw legacy bridge (historical)
+## OpenClaw and Hermes coexist
 
-`~/.openclaw/` is kept as a 30-day standby for rollback after the 2026-04-21 Hermes retarget. `ai.openclaw.gateway.plist` stays loaded until BNC on Hermes completes at least one full successful scheduled run. Once confirmed, decommission with:
-
-```bash
-ssh m1-pro 'launchctl unload ~/Library/LaunchAgents/ai.openclaw.gateway.plist'
-```
-
-Do not delete `~/.openclaw/` until the 30-day window passes. The OpenClaw BNC cron entry on m1-pro is commented out with a `# DEPRECATED-HERMES` prefix (not deleted) to preserve the rollback path.
+OpenClaw and Hermes run in parallel on m1-pro. A single skill whose `agent_skill_scope` lists both `openclaw` and `hermes` is deployed to both runtimes in the same run — OpenClaw via rsync to its workspace (see the `openclaw` skill for the current workspace path), Hermes via the `docker cp` leg above. Do not treat either runtime as deprecated unless the skill's own stub explicitly carries `deprecated: true`.

--- a/skills/terminology/SKILL.md
+++ b/skills/terminology/SKILL.md
@@ -15,6 +15,10 @@ description: >
 
 Create or maintain terminology notes in `50. AI/02 Terminologies/`. The SSOT for this skill's prompt and template is `50. AI/04 Skills/terminology/SKILL.md`. The canonical template is at `references/template.md` (exact extraction from the SSOT prompt). Handles variant detection, boilerplate cleanup, and duplicate merging via obsidian CLI. Produces one note; does not modify neighboring notes.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 
 - Use when the user wants a terminology note for a concept

--- a/skills/youtube-upload/evals/evals.json
+++ b/skills/youtube-upload/evals/evals.json
@@ -1,0 +1,95 @@
+{
+  "skill_name": "youtube-upload",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Upload this video to YouTube: /tmp/test_video.mp4",
+      "expected_output": "Video uploaded to YouTube with generated title/description/tags, vault note created in 15. Work/02 Area/Youtube/",
+      "files": [],
+      "expectations": [
+        "The skill ran transcribe.py via uv run to extract transcript",
+        "The skill generated a title under 90 characters from the transcript",
+        "The skill generated a description with 1-line summary + bullet points + CTA",
+        "The skill generated 5-12 tags as comma-separated list",
+        "The skill ran upload.py via uv run with --privacy private",
+        "The skill created a vault note via obsidian create at 15. Work/02 Area/Youtube/<title>.md",
+        "The skill set frontmatter properties including type=video and status=done",
+        "The skill set tags as list type: reference,reference/video,youtube/uploaded",
+        "The skill set image to https://img.youtube.com/vi/<video_id>/maxresdefault.jpg",
+        "The skill used key=value syntax for obsidian CLI (not --flag style)",
+        "The skill appended < /dev/null to obsidian property:set calls"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "youtube upload /tmp/test_video.mp4 --title 'My Custom Title'",
+      "expected_output": "Video uploaded with the user-provided title override, not auto-generated",
+      "files": [],
+      "expectations": [
+        "The skill used 'My Custom Title' as the title instead of generating one",
+        "The skill still ran transcribe.py to get the transcript (needed for description/tags)",
+        "The skill still generated description and tags from the transcript",
+        "The skill ran upload.py with the custom title",
+        "The vault note was created at 15. Work/02 Area/Youtube/My Custom Title.md"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "영상 업로드 /tmp/test_video.mp4",
+      "expected_output": "Skill triggered by Korean phrase and completed the full upload pipeline",
+      "files": [],
+      "expectations": [
+        "The skill was triggered by the Korean phrase '영상 업로드'",
+        "The full pipeline completed (transcribe, metadata, upload, dedup check, vault note, confirm)",
+        "The vault note was created at 15. Work/02 Area/Youtube/ (not 86. Videos/ or 80. References/)"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Upload this video: /tmp/test_video.mp4 --privacy unlisted",
+      "expected_output": "Video uploaded with unlisted privacy status",
+      "files": [],
+      "expectations": [
+        "The skill passed --privacy unlisted to upload.py",
+        "The confirm step reports Privacy: unlisted",
+        "All other pipeline steps completed normally"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Upload this video to YouTube: /tmp/test_video.mp4",
+      "expected_output": "When credentials are missing, the skill provides clear setup instructions",
+      "files": [],
+      "expectations": [
+        "If upload.py exits with credential error, the skill tells the user to run --auth-only",
+        "The skill mentions the credential path ~/.config/youtube-upload/credentials.json",
+        "The skill does NOT attempt to create or modify credentials itself",
+        "The skill mentions agent-browser automated setup as an alternative"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Upload this 2-hour lecture recording: /tmp/long_lecture.mp4",
+      "expected_output": "Long video handled with appropriate warning and increased timeout awareness",
+      "files": [],
+      "expectations": [
+        "The skill warns that the video is over 1 hour and transcription may take several minutes",
+        "The skill still runs transcribe.py (max_tokens=200000 covers ~3 hours)",
+        "The skill does not truncate the transcript",
+        "Upload uses resumable upload with 5MB chunks (handles large files)"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Upload /tmp/test_video.mp4 to YouTube",
+      "expected_output": "Duplicate check prevents creating a second vault note for an already-registered video",
+      "files": [],
+      "expectations": [
+        "The skill runs obsidian search for the video_id before creating a vault note",
+        "If a note with the same video_id already exists, the skill warns the user",
+        "The skill reports the existing note path and skips note creation",
+        "The upload to YouTube itself still proceeds (dedup is vault-side only)"
+      ]
+    }
+  ]
+}

--- a/skills/zotero/SKILL.md
+++ b/skills/zotero/SKILL.md
@@ -14,6 +14,10 @@ description: >
 
 Full Zotero workflow covering `zt` CLI (search, import, export, batch ops) and the Obsidian vault pipeline (import → normalize → sync → review). Paper notes live at `80. References/02 Paper/{citekey}.md`. BetterBibTeX must be enabled for correct citekey-based filenames.
 
+## Vault Access
+
+Use the `obsidian-cli` skill for all note creation, edit, search, and property mutation inside the Ataraxia vault. Do not shell out to raw `cat`/`sed` on vault paths. See the `obsidian-cli` SKILL.md for the command surface and required preconditions (Obsidian must be running).
+
 ## When to Use
 
 - Use when the user wants to search Zotero, import a paper note, sync annotations, or create a review note


### PR DESCRIPTION
## Summary
- Propagates vault SSOT changes for all 26 publishable skills
- Rename `Skill Guideline.md` → `11. Skill Guideline.md`; stub field rename `deploy_scope` → `agent_skill_scope`
- `Obsidian/` subfolder path reorg applied to all in-skill path refs
- openclaw deprecation banner removed (Hermes + openclaw coexist)
- Per-skill guideline compliance edits (Vault Access section, English-first authoring, mermaid/markdown rules)
- Bumps plugin version 1.0.24 → 1.0.25

## Test plan
- [ ] `claude plugins update agent-skills@beomsu-koh` exits 0 on local
- [ ] Same update runs clean on m1-pro via tailscale
- [ ] Hermes global dir `/root/.hermes/skills/<skill>/SKILL.md` present for all 26