### PR TITLE
deploy(skill-deploy): native Hermes rsync + seven-leg target map (v1.0.26)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-skills",
   "description": "Personal Claude Code skill collection by Beomsu Koh",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "author": {
     "name": "Beomsu Koh"
   },

--- a/skills/skill-deploy/SKILL.md
+++ b/skills/skill-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-deploy
-description: Push publishable skills from the vault SSOT to GoBeromsu/obsidian-agent-skills on GitHub, then fan out to every runtime declared in each skill's `agent_skill_scope` — Codex CLI (`~/.codex/skills/`), local + m1-pro Claude Code (`~/.claude/skills/Obsidian/`), m1-pro OpenClaw workspace, and m1-pro Hermes Docker runtime (`~/.hermes/skills/`). Use when the user says "/skill-deploy", "스킬 배포", "publish skills", or wants to update any deployed skill surface from the vault SSOT after skill edits.
+description: Push publishable skills from the vault SSOT to GoBeromsu/obsidian-agent-skills on GitHub, then fan out to every runtime declared in each skill's `agent_skill_scope` — Codex CLI (`~/.codex/skills/`), local + m1-pro Claude Code (`agent-skills@beomsu-koh` plugin), m1-pro OpenClaw workspace (`~/.openclaw/skills/`), and m1-pro native Hermes runtime (`~/.hermes/skills/openclaw-imports/`). Use when the user says "/skill-deploy", "스킬 배포", "publish skills", or wants to update any deployed skill surface from the vault SSOT after skill edits.
 ---
 
 # skill-deploy
@@ -11,7 +11,7 @@ Use the `obsidian-cli` skill for all note creation, edit, search, and property m
 
 ## Overview
 
-Push publishable skills from the vault SSOT to GitHub, then fan out to every downstream surface declared in each skill's `agent_skill_scope` list. The vault copy under `50. AI/04 Skills/Obsidian/` is the source of truth; GitHub, Codex CLI, local + m1-pro Claude Code, m1-pro OpenClaw, and m1-pro Hermes Docker are mirrors. All surfaces listed on a skill must be updated in the same run, or agents reading from a stale surface will silently drift. See also `[[504.02 Hermes]]`, `[[Hermes Agent]]`, `[[11. Skill Guideline]]`.
+Push publishable skills from the vault SSOT to GitHub, then fan out to every downstream surface declared in each skill's `agent_skill_scope` list. The vault copy under `50. AI/04 Skills/Obsidian/` is the source of truth; GitHub, Codex CLI, local + m1-pro Claude Code, m1-pro OpenClaw, and m1-pro native Hermes are mirrors. All surfaces listed on a skill must be updated in the same run, or agents reading from a stale surface will silently drift. See also `[[504.02 Hermes]]`, `[[Hermes Agent]]`, `[[11. Skill Guideline]]`.
 
 ## When to Use
 
@@ -26,14 +26,15 @@ One source, five sinks. Each skill declares which sinks receive it through its `
 
 | # | `agent_skill_scope` value | Target | Transport | Destination | Sync Command |
 |---|---|--------|-----------|-------------|--------------|
-| 1 | (always) | GitHub SSOT mirror | Branch + PR + squash-merge via `gh` | `GoBeromsu/obsidian-agent-skills` (main), under `skills/Obsidian/` | Step 5: `gh pr create` → `gh pr merge --squash --admin` |
-| 2 | `claude` | Local Claude Code plugin | `claude plugins update` | `~/.claude/skills/Obsidian/<skill>/` | `claude plugins update obsidian-agent-skills@beomsu-koh` |
-| 3 | `claude` | m1-pro Claude Code plugin | ssh over tailscale | same path on m1-pro | `ssh m1-pro claude plugins update obsidian-agent-skills@beomsu-koh` |
-| 4 | `codex` | Codex CLI | rsync | `~/.codex/skills/<skill>/` | `rsync -av --delete "$VAULT/<skill>/" ~/.codex/skills/<skill>/` |
-| 5 | `openclaw` | m1-pro OpenClaw workspace | rsync over ssh (tailscale) | OpenClaw skills path on m1-pro (managed by the `openclaw` skill) | per-skill rsync |
-| 6 | `hermes` | m1-pro Hermes global skills | docker cp via ssh (tailscale) | `$HC:/root/.hermes/skills/<skill>/` | per-skill rsync stage → `docker cp` |
+| 1 | (always) | GitHub SSOT mirror | Branch + PR + squash-merge via `gh` | `GoBeromsu/obsidian-agent-skills` (main), under `skills/<skill>/` | Step 5: `gh pr create` → `gh pr merge --squash --admin` |
+| 2 | `claude` | Local Claude Code plugin | `claude plugins update` | `~/.claude/plugins/cache/beomsu-koh/agent-skills/<ver>/skills/<skill>/` | `claude plugins update agent-skills@beomsu-koh` |
+| 3 | `claude` | m1-pro Claude Code plugin | ssh over tailscale | same path on m1-pro | `ssh m1-pro claude plugins update agent-skills@beomsu-koh` |
+| 4 | `codex` | Local Codex CLI | rsync | `~/.codex/skills/<skill>/` | per-skill `rsync -a --delete` |
+| 5 | `codex` | m1-pro Codex CLI | rsync over ssh (tailscale) | `~/.codex/skills/<skill>/` on m1-pro | per-skill `rsync -a --delete` |
+| 6 | `openclaw` | m1-pro OpenClaw workspace | rsync over ssh (tailscale) | `~/.openclaw/skills/<skill>/` on m1-pro | per-skill `rsync -a --delete` |
+| 7 | `hermes` | m1-pro native Hermes runtime | rsync over ssh (tailscale) | `~/.hermes/skills/openclaw-imports/<skill>/` on m1-pro | per-skill `rsync -a --delete` |
 
-Target #1 (GitHub) is the SSOT mirror and always runs; every other target is conditional on the presence of its scope value in the skill's `agent_skill_scope`. Skills without `publish: true` are vault-only and filtered in Step 1. Hermes has private skills from `hermes claw migrate`; `docker cp` per-skill is the only safe ingress. Full rationale: `references/hermes-target.md`.
+Target #1 (GitHub) is the SSOT mirror and always runs; every other target is conditional on the presence of its scope value in the skill's `agent_skill_scope`. Skills without `publish: true` are vault-only and filtered in Step 1. Hermes, OpenClaw, and Codex each host sibling skills the vault does not own (e.g., Hermes private skills from `hermes claw migrate`); per-skill `rsync -a --delete` scoped to a single `<skill>/` directory removes only stale files inside that skill, never sibling skills. Full rationale: `references/hermes-target.md`.
 
 ## Process
 
@@ -45,46 +46,50 @@ For each subdirectory: verify `SKILL.md` exists; check `{skill-name}.md` for `pu
 
 ### Steps 2–5 — Repo prep, copy, version bump, PR
 
-Full bash blocks in `references/hermes-target.md § GitHub deploy runbook`. Key invariants: always `git pull --rebase` before branching; copy each skill into `$REPO/skills/Obsidian/<skill>/`; always bump `.claude-plugin/plugin.json`; use `gh pr merge --squash --admin --delete-branch`; never push directly to `main`. After copying each skill write the scope list: `printf '%s\n' "${scope[@]}" > "$REPO/skills/Obsidian/$skill/.agent_skill_scope"` — Step 6 reads this file.
+Full bash blocks in `references/hermes-target.md § GitHub deploy runbook`. Key invariants: always `git pull --rebase` before branching; rsync each vault skill into `$REPO/skills/<skill>/` with `--exclude="<skill>.md"` so the vault stub is not published; always bump `.claude-plugin/plugin.json`; use `gh pr merge --squash --admin --delete-branch`; never push directly to `main`. After copying each skill write the scope list: `printf '%s\n' "${scope[@]}" > "$REPO/skills/$skill/.agent_skill_scope"` — Step 6 reads this file.
 
 ### Step 6 — Sync Deployed Mirrors
 
 **6a. Claude Code plugins (target #2 + #3, gated on `claude` in scope):**
 
 ```bash
-claude plugins update obsidian-agent-skills@beomsu-koh
-ssh m1-pro claude plugins update obsidian-agent-skills@beomsu-koh
+claude plugins update agent-skills@beomsu-koh
+ssh m1-pro claude plugins update agent-skills@beomsu-koh
 ```
 
-**6b. Codex CLI (target #4, gated on `codex` in scope):**
+**6b. Codex CLI — local + m1-pro (targets #4 + #5, gated on `codex` in scope):**
 
 ```bash
 mkdir -p ~/.codex/skills
-for skill in $(ls "$REPO/skills/Obsidian"); do
-  grep -qx codex "$REPO/skills/Obsidian/$skill/.agent_skill_scope" || continue
-  rsync -av --delete "$REPO/skills/Obsidian/$skill/" "$HOME/.codex/skills/$skill/"
+ssh m1-pro 'mkdir -p ~/.codex/skills'
+for skill in $(ls "$REPO/skills"); do
+  grep -qx codex "$REPO/skills/$skill/.agent_skill_scope" || continue
+  rsync -a --delete "$REPO/skills/$skill/" "$HOME/.codex/skills/$skill/"
+  rsync -a --delete "$REPO/skills/$skill/" "m1-pro:.codex/skills/$skill/"
 done
 ```
 
-**6c. m1-pro OpenClaw workspace (target #5, gated on `openclaw` in scope):** follow the `openclaw` skill for the current workspace path; deploy per-skill rsync after confirming the OpenClaw gateway is healthy.
-
-**6d. m1-pro Hermes runtime (target #6, gated on `hermes` in scope):**
+**6c. m1-pro OpenClaw workspace (target #6, gated on `openclaw` in scope):**
 
 ```bash
-HC=$(ssh m1-pro 'docker ps --filter name=hermes --format "{{.Names}}" | head -1')
-ssh m1-pro 'mkdir -p ~/.hermes-stage'
-for skill in $(ls "$REPO/skills/Obsidian"); do
-  grep -qx hermes "$REPO/skills/Obsidian/$skill/.agent_skill_scope" || continue
-  rsync -av --delete "$REPO/skills/Obsidian/$skill/" "m1-pro:.hermes-stage/$skill/"
-  ssh m1-pro "docker cp ~/.hermes-stage/$skill $HC:/root/.hermes/skills/"
+for skill in $(ls "$REPO/skills"); do
+  grep -qx openclaw "$REPO/skills/$skill/.agent_skill_scope" || continue
+  rsync -a --delete "$REPO/skills/$skill/" "m1-pro:.openclaw/skills/$skill/"
 done
 ```
 
-Hermes cron CLI fallback and container lifecycle notes: `references/hermes-target.md`.
+**6d. m1-pro native Hermes runtime (target #7, gated on `hermes` in scope):**
+
+```bash
+for skill in $(ls "$REPO/skills"); do
+  grep -qx hermes "$REPO/skills/$skill/.agent_skill_scope" || continue
+  rsync -a --delete "$REPO/skills/$skill/" "m1-pro:.hermes/skills/openclaw-imports/$skill/"
+done
+```
 
 ### Step 7 — Report
 
-Print deployed/skipped counts for all six targets. Verify remote: `gh api repos/GoBeromsu/obsidian-agent-skills/contents/skills/Obsidian --jq '.[].name'`.
+Print deployed/skipped counts for all seven targets. Verify remote: `gh api repos/GoBeromsu/obsidian-agent-skills/contents/skills --jq '.[].name'`.
 
 ## Common Rationalizations
 
@@ -92,25 +97,27 @@ Print deployed/skipped counts for all six targets. Verify remote: `gh api repos/
 |---|---|
 | "The push succeeded so every machine is up to date." | Push updates GitHub only. Every target declared in a skill's `agent_skill_scope` must run its own sync. |
 | "I'll edit the deployed plugin cache directly." | Cache is overwritten on next update. Edit the SSOT only. |
-| "Plugins update covers Hermes too." | Hermes reads only `~/.hermes/skills/`. Without `docker cp`, it keeps yesterday's skill. |
-| "I'll rsync directly into the running container." | Unreliable across Docker overlayfs. Stage on host first, then `docker cp`. |
+| "Plugins update covers Hermes too." | Hermes reads only `~/.hermes/skills/openclaw-imports/`. Without a per-skill rsync it keeps yesterday's skill. |
+| "I can rsync at the `~/.hermes/skills/openclaw-imports/` root with `--delete`." | Hermes has private skills alongside vault ones; root-level `--delete` destroys them. Scope each rsync to one `<skill>/` directory. |
 | "A skill with missing `agent_skill_scope` should fan out everywhere." | Missing field defaults to `[claude]` only, with a WARN. Silent fan-out risks publishing to a surface the author did not intend. |
 
 ## Red Flags
 
 - `git push origin main` directly (blocked by agent policy)
 - Pushing without bumping `.claude-plugin/plugin.json` version
-- Running `rsync -av --delete` directly into a live container overlayfs without staging on host first
+- Running `rsync --delete` at a runtime's skills root (`~/.hermes/skills/openclaw-imports/`, `~/.openclaw/skills/`, `~/.codex/skills/`) instead of per-skill — destroys sibling private skills
 - Adding a new deployment target without updating the Deployment Targets table and `agent_skill_scope` target map in `[[11. Skill Guideline]]`
-- Skipping the Hermes `docker cp` leg because "the plugin update already ran"
+- Skipping the Hermes rsync leg because "the plugin update already ran"
 - Treating the absence of `agent_skill_scope` as "deploy to everything"
+- Publishing the vault stub `{skill-name}.md` into the repo instead of excluding it from the rsync
 
 ## Verification
 
 - [ ] Each deployed skill has `publish: true` in its `{skill-name}.md` and a valid `agent_skill_scope` list; `.claude-plugin/plugin.json` bumped
 - [ ] PR squash-merged `--admin --delete-branch`; local `main` rebased
-- [ ] `claude plugins update obsidian-agent-skills@beomsu-koh` exits 0 on local and m1-pro for every skill with `claude` in scope
-- [ ] Codex surface: `ls ~/.codex/skills/<skill>/SKILL.md` returns path for every skill with `codex` in scope
-- [ ] OpenClaw surface: skill present in the OpenClaw workspace for every skill with `openclaw` in scope
-- [ ] Hermes global: `ssh m1-pro "docker exec $HC ls /root/.hermes/skills/<skill>/SKILL.md"` returns path for every skill with `hermes` in scope
-- [ ] Hermes-private skills still present; deployment report covers all six targets
+- [ ] `claude plugins update agent-skills@beomsu-koh` exits 0 on local and m1-pro for every skill with `claude` in scope
+- [ ] Local Codex: `ls ~/.codex/skills/<skill>/SKILL.md` returns path for every skill with `codex` in scope
+- [ ] m1-pro Codex: `ssh m1-pro "ls ~/.codex/skills/<skill>/SKILL.md"` returns path for every skill with `codex` in scope
+- [ ] OpenClaw: `ssh m1-pro "ls ~/.openclaw/skills/<skill>/SKILL.md"` returns path for every skill with `openclaw` in scope
+- [ ] Hermes: `ssh m1-pro "ls ~/.hermes/skills/openclaw-imports/<skill>/SKILL.md"` returns path for every skill with `hermes` in scope
+- [ ] Sibling private skills on Hermes / OpenClaw / Codex still present (per-skill `--delete` scope preserved them); deployment report covers all seven targets

--- a/skills/skill-deploy/references/hermes-target.md
+++ b/skills/skill-deploy/references/hermes-target.md
@@ -1,19 +1,21 @@
 # hermes-target — skill-deploy reference
 
-## Why Hermes (not ClawHub) + why per-skill docker cp
+## Why native Hermes (not Docker) + why per-skill rsync
 
-Hermes classifies skills by source similarly to OpenClaw's `openclaw-managed` pattern. ClawHub's CLI (`openclaw skills install` / `update`) was always a read-only consume path for third-party skills — there was no publish command and no local `clawhub` CLI for pushing a vault SSOT upstream. Hermes inherits the same model: skills you own live in `~/.hermes/skills/<name>/` (global) or `~/.hermes/agents/<agent>/workspace/skills/<name>/` (agent-scoped), and the only safe ingress is `docker cp`.
+Hermes now runs natively on m1-pro (`/Users/beomsu/.local/bin/hermes`, v0.10.0+). The prior Docker path is retired. Skills the vault owns land at `~/.hermes/skills/openclaw-imports/<name>/`; the parent `openclaw-imports/` folder groups everything that entered Hermes through the vault-SSOT pipeline. Sibling Hermes-private skills (installed via `hermes claw migrate`) live alongside them in the same folder.
 
-Running `docker cp` per-skill (rather than at the `~/.hermes/skills/` root) is essential because Hermes may have private skills installed by `hermes claw migrate` that are not in the vault. A root-level copy or rsync with `--delete` would destroy them. Scoping to one `$skill/` directory removes only stale files inside that skill, never sibling skills.
+Because private skills and vault skills coexist under `openclaw-imports/`, a root-level `rsync --delete` would destroy private skills. The safe pattern is per-skill rsync scoped to a single `<skill>/` directory — `--delete` then removes only stale files inside that skill, never sibling skills. The same rule applies to OpenClaw (`~/.openclaw/skills/`) and Codex (`~/.codex/skills/`): each hosts sibling skills the vault does not own.
 
-Direct `rsync` into a running container's overlayfs is unreliable — Docker overlayfs does not guarantee atomic visibility of rsync's incremental writes. The safe pattern is: rsync to a host staging directory (`~/.hermes-stage/`), then `docker cp` the staged directory into the container in a single operation.
+Hermes classifies skills by source similarly to OpenClaw's `openclaw-managed` pattern. ClawHub's CLI (`openclaw skills install` / `update`) was a read-only consume path for third-party skills — there was no publish command and no local `clawhub` CLI for pushing a vault SSOT upstream. Hermes inherits the same model: skills you own ingress via per-skill rsync; there is no publish command on the Hermes side.
 
-Historical note: before 2026-04-21, target #4 deployed to `m1-pro:~/.openclaw/skills/` via rsync. The `~/.openclaw/` tree is kept as a 30-day standby (`ai.openclaw.gateway.plist` stays loaded until BNC on Hermes completes its first successful scheduled run). After that, unload with `launchctl unload ~/Library/LaunchAgents/ai.openclaw.gateway.plist`.
+Historical notes:
+- Before 2026-04-22, Hermes ingress was `rsync → host stage → docker cp` into a Docker container. The container path was deprecated when Hermes moved to a native install; all deploys now use plain filesystem rsync over ssh.
+- Before 2026-04-21, target `openclaw` deployed to `m1-pro:~/.openclaw/skills/` only. The `~/.openclaw/` tree is kept as a 30-day standby (`ai.openclaw.gateway.plist` stays loaded until BNC on Hermes completes its first successful scheduled run). After that, unload with `launchctl unload ~/Library/LaunchAgents/ai.openclaw.gateway.plist`.
 
 ## GitHub deploy runbook (Steps 2–5)
 
 ```bash
-REPO="${OBSIDIAN_AGENT_SKILLS_REPO_PATH:-$HOME/dev/obsidian-agent-skills}"
+REPO="${OBSIDIAN_AGENT_SKILLS_REPO_PATH:-$HOME/dev/agent-skills}"
 VAULT="/Users/beomsu/Documents/01. Obsidian/Ataraxia/50. AI/04 Skills/Obsidian"
 
 # Step 2 — Prepare repo
@@ -25,14 +27,15 @@ if [ ! -d "$REPO/.git" ]; then
 fi
 git -C "$REPO" pull --rebase
 
-# Step 3 — Copy publishable skills
+# Step 3 — Copy publishable skills (exclude vault stub from repo)
 for skill in <publishable-skill-list>; do
-  DEST="$REPO/skills/Obsidian/$skill"
+  DEST="$REPO/skills/$skill"
   mkdir -p "$DEST"
-  cp "$VAULT/$skill/SKILL.md" "$DEST/"
-  for dir in scripts references assets; do
-    [ -d "$VAULT/$skill/$dir" ] && cp -r "$VAULT/$skill/$dir/" "$DEST/$dir/"
-  done
+  rsync -a --delete \
+    --exclude="$skill.md" \
+    --exclude=".DS_Store" \
+    --exclude=".obsidian" \
+    "$VAULT/$skill/" "$DEST/"
   # Write agent_skill_scope marker for Step 6 gating
   STUB="$VAULT/$skill/$skill.md"
   awk '/^agent_skill_scope:/{flag=1;next} /^[a-zA-Z_]+:/{flag=0} flag && /^  - /{print $2}' "$STUB" > "$DEST/.agent_skill_scope"
@@ -74,50 +77,57 @@ git -C "$REPO" pull --rebase
 
 **Why `--delete-branch`?** Keeps the branch list clean. The squash-merged content is already on `main`.
 
-## Hermes cron CLI fallback runbook
+**Repo rename note.** The repo was renamed on GitHub from `GoBeromsu/agent-skills` to `GoBeromsu/obsidian-agent-skills`. Pushes to the old URL still succeed via GitHub's redirect, but `gh` subcommands that require an explicit repo flag must use the new name (`--repo GoBeromsu/obsidian-agent-skills`). The Claude Code plugin name is still `agent-skills@beomsu-koh` — the plugin name is independent of the repo slug and should not be renamed lightly (settings, marketplace, and cache paths all key off it).
 
-Preferred path — if the Hermes CLI supports it:
+## Hermes cron runbook
 
-```bash
-ssh m1-pro "docker exec $HC hermes cron add --agent xia --skill brian-note-challenge --schedule '0 7 * * *'"
-ssh m1-pro "docker exec $HC hermes cron list"
-```
-
-Fallback — if `hermes cron` CLI is unavailable, use host crontab:
+Preferred path — the Hermes CLI supports cron directly:
 
 ```bash
-# On m1-pro
-crontab -e
-# Add:
-0 7 * * * docker exec $HC hermes skill run brian-note-challenge
+ssh m1-pro "hermes cron add --agent xia --skill brian-note-challenge --schedule '0 7 * * *'"
+ssh m1-pro "hermes cron list"
 ```
 
-Guardrail: never run `docker cp` during a cron quiet window while the skill is actively executing. If deploying to a busy container, signal graceful shutdown first:
+Fallback — if `hermes cron` is unavailable for a given build, use host crontab on m1-pro:
 
 ```bash
-ssh m1-pro "docker exec $HC pkill -SIGTERM hermes-gateway"
-# wait for shutdown, then docker cp, then restart
-ssh m1-pro "docker exec $HC hermes gateway start"
+ssh m1-pro 'crontab -l'
+# To edit interactively:
+ssh m1-pro -t 'crontab -e'
+# Sample entry:
+# 0 7 * * * /Users/beomsu/.local/bin/hermes skill run brian-note-challenge
 ```
 
-## Container lifecycle notes
-
-Confirm vault is mounted into the container:
+Guardrail: do not rsync a Hermes skill while it is actively executing. If the skill has a long-running cron job, schedule deploys during quiet windows or signal a graceful pause first:
 
 ```bash
-ssh m1-pro 'docker inspect $HC --format "{{json .Mounts}}"' | jq .
+ssh m1-pro "hermes gateway stop"
+# deploy (per-skill rsync)
+ssh m1-pro "hermes gateway start"
 ```
 
-If the vault is not mounted, BNC (and any other vault-writing skill) will fail silently. Remediation: recreate the container with `-v $HOME/Documents/01. Obsidian:/obsidian` and re-run `hermes claw migrate`.
+## Runtime verification
 
-Verify `gws` auth is alive inside the container before the first cron run:
+Confirm the native Hermes binary is present and healthy:
 
 ```bash
-ssh m1-pro "docker exec $HC gws auth status"
+ssh m1-pro 'which hermes && hermes --version'
 ```
 
-If auth is missing, either run `docker exec $HC gws auth login` or bind-mount the host credentials: add `-v $HOME/.config/gws:/root/.config/gws` to the container run command.
+Confirm the expected skill landed:
+
+```bash
+ssh m1-pro "ls ~/.hermes/skills/openclaw-imports/<skill>/SKILL.md"
+```
+
+Verify `gws` auth is alive before the first cron run for any skill that writes to Google Workspace:
+
+```bash
+ssh m1-pro "gws auth status"
+```
+
+If auth is missing, run `ssh m1-pro "gws auth login"`.
 
 ## OpenClaw and Hermes coexist
 
-OpenClaw and Hermes run in parallel on m1-pro. A single skill whose `agent_skill_scope` lists both `openclaw` and `hermes` is deployed to both runtimes in the same run — OpenClaw via rsync to its workspace (see the `openclaw` skill for the current workspace path), Hermes via the `docker cp` leg above. Do not treat either runtime as deprecated unless the skill's own stub explicitly carries `deprecated: true`.
+OpenClaw and Hermes run in parallel on m1-pro. A single skill whose `agent_skill_scope` lists both `openclaw` and `hermes` is deployed to both runtimes in the same run — OpenClaw via per-skill rsync to `~/.openclaw/skills/<skill>/`, Hermes via per-skill rsync to `~/.hermes/skills/openclaw-imports/<skill>/`. Both use plain filesystem transport over tailscale ssh; neither requires Docker. Do not treat either runtime as deprecated unless the skill's own stub explicitly carries `deprecated: true`.


### PR DESCRIPTION
## Summary
- Replaces Docker-cp Hermes ingress with per-skill rsync to `~/.hermes/skills/openclaw-imports/<skill>/`
- Fixes repo layout docs to flat `skills/<skill>/` (matches actual)
- Fixes plugin name docs to `agent-skills@beomsu-koh` (unchanged despite repo rename)
- Expands target table from 6 → 7 legs (explicit local + m1-pro Codex split)

## Test plan
- [x] Local Codex rsync lands correctly
- [x] m1-pro Codex rsync lands correctly
- [x] m1-pro OpenClaw rsync preserves siblings
- [x] m1-pro Hermes (native) rsync lands at openclaw-imports